### PR TITLE
Add installation instructions for Edge

### DIFF
--- a/docs/adguard-browser-extension/installation.md
+++ b/docs/adguard-browser-extension/installation.md
@@ -47,6 +47,23 @@ In the opened dialog window, press _Add extension_.
 
 ![Edge dialog window *border](https://cdn.adtidy.org/content/Kb/ad_blocker/browser_extension/ad_blocker_browser_extension_edge1.png)
 
+Alternatively, you install AdGuard Browser extension for Edge from the [Chrome Web Store](https://agrd.io/extension_chrome). Open its web page in your Edge browser and select *Allow extensions from other stores* in the banner at the top of the page.
+
+![Edge banner on the Chrome Web Store *border](https://cdn.adtidy.org/content/Kb/ad_blocker/browser_extension/edge_banner.jpg)
+
+In the opened dialog box, click *Allow*.
+
+![Edge dialog box “Allow extensions from other web stores”](https://cdn.adtidy.org/content/Kb/ad_blocker/browser_extension/allow_from_stores.jpg)
+
+Click *Add to Chrome*.
+
+![Add to Chrome button *border](https://cdn.adtidy.org/content/Kb/ad_blocker/browser_extension/add_to_chrome.jpg)
+
+In the opened dialog window, click *Add extension* to install AdGuard for Edge. 
+
+![Add to Edge button](https://cdn.adtidy.org/content/Kb/ad_blocker/browser_extension/add_to_edge.jpg)
+
+
 ## How to install AdGuard Browser extension for Safari
 
 AdGuard for Safari is not a browser extension in a common sense. You can read more about it in a [devoted artile](/adguard-for-safari/overview). Or you can [download the installation file](https://agrd.io/safari_release) directly from this page.

--- a/docs/adguard-browser-extension/installation.md
+++ b/docs/adguard-browser-extension/installation.md
@@ -47,7 +47,7 @@ In the opened dialog window, press _Add extension_.
 
 ![Edge dialog window *border](https://cdn.adtidy.org/content/Kb/ad_blocker/browser_extension/ad_blocker_browser_extension_edge1.png)
 
-Alternatively, you install AdGuard Browser extension for Edge from the [Chrome Web Store](https://agrd.io/extension_chrome). Open its web page in your Edge browser and select *Allow extensions from other stores* in the banner at the top of the page.
+Alternatively, you can install AdGuard Browser extension for Edge from the [Chrome Web Store](https://agrd.io/extension_chrome). Open its web page in your Edge browser and select *Allow extensions from other stores* on the banner at the top of the page.
 
 ![Edge banner on the Chrome Web Store *border](https://cdn.adtidy.org/content/Kb/ad_blocker/browser_extension/edge_banner.jpg)
 
@@ -59,11 +59,11 @@ Click *Add to Chrome*.
 
 ![Add to Chrome button *border](https://cdn.adtidy.org/content/Kb/ad_blocker/browser_extension/add_to_chrome.jpg)
 
-In the opened dialog window, click *Add extension* to install AdGuard for Edge. 
+In the opened dialog window, click *Add extension* to install AdGuard Browser extension. 
 
 ![Add to Edge button](https://cdn.adtidy.org/content/Kb/ad_blocker/browser_extension/add_to_edge.jpg)
 
 
 ## How to install AdGuard Browser extension for Safari
 
-AdGuard for Safari is not a browser extension in a common sense. You can read more about it in a [devoted artile](/adguard-for-safari/overview). Or you can [download the installation file](https://agrd.io/safari_release) directly from this page.
+AdGuard for Safari is not a browser extension in a common sense. You can read more about it in a [dedicated artile](/adguard-for-safari/overview). Or you can [download the installation file](https://agrd.io/safari_release) directly from this page.


### PR DESCRIPTION
Added instructions to install AdGuard for Edge from the Chrome Web Store based on https://github.com/AdguardTeam/KnowledgeBase/issues/113 and https://github.com/AdguardTeam/AdguardKnowledgeBase/pull/1143