### PR TITLE
Issue #99: Create https-certificate-for-rooted.md

### DIFF
--- a/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
+++ b/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
@@ -56,7 +56,7 @@ you'll have to reboot the device for the new certificate to be copied to the sys
 
 ### Bromite browser
 
-Please note that in order for **Bromite** browser to work properly, in addition to the steps mentioned above, you need to enable the "Allow user certificates" flag in `chrome://flags`.
+Please note that in order for **Bromite** browser to work properly, in addition to the steps mentioned above, you need to set "Allow user certificates" in `chrome://flags` to "Enabled" state.
 
 ### Chrome and Chromium-based browsers
 

--- a/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
+++ b/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
@@ -1,20 +1,20 @@
 ---
-title: Moving certificate to system storage on rooted devices
+title: Moving CA certificate to System store on rooted devices
 sidebar_position: 13
 ---
 
 AdGuard for Android provides a feature called [HTTPS filtering](../../overview#https-filtering) that makes it possible to [filter encrypted HTTPS traffic](/general/https-filtering/what-is-https-filtering) on your Android device. This feature requires adding the AdGuard's CA certificate to the list of trusted certificates.
 
-On a non-rooted devices CA certificates can be installed to the **User store**. Only a limited subset of apps (mostly, browsers) trust CA certificates installed to the User store, meaning HTTPS filtering won't work for apps that don't trust it.
+On non-rooted devices CA certificates can be installed to the **User store**. Only a limited subset of apps (mostly browsers) trust CA certificates installed to the User store, meaning HTTPS filtering will work only for such apps.
 
 However, on rooted devices, you can install the certificate to the **System store** and allow HTTPS filtering of other apps' traffic too.
 
 Here's how to do that.
 
-## How to install AdGuard Certificate to System store (on a rooted device)
+## How to install AdGuard's Certificate to System store (on a rooted device)
 
 1. Enable HTTPS filtering in AdGuard for Android and save AdGuard's certificate to the User store (use [this instruction](../../overview#https-filtering) if needed)
-2. Go to **AdGuard app** → **Menu** (≡) → **Settings** → **Network** → **HTTPS filtering** → **Secure certificate** → tap “**Copy to the system store**”
+2. Go to **AdGuard app** → **Menu** (≡) → **Settings** → **Network** → **HTTPS filtering** → **Security certificate** → tap “**Copy to the system store**”
 tap “**Copy to the system store**”
 
 That is enough for older versions of Magisk.
@@ -56,7 +56,7 @@ you'll have to reboot the device for the new certificate to be copied to the sys
 
 ### Bromite browser
 
-Please note that in order for **Bromite** browser to work properly, in addition to the steps mentioned above, you need to set flag "Allow user certificates" in `chrome://flags` to "Enabled" state.
+Please note that in order for **Bromite** browser to work properly, in addition to the steps mentioned above, you need to enable the "Allow user certificates" flag in `chrome://flags`.
 
 ### Chrome and Chromium-based browsers
 

--- a/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
+++ b/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
@@ -1,5 +1,5 @@
 ---
-title: Moving CA certificate to System store on rooted devices
+title: Moving CA certificate to the System store on rooted devices
 sidebar_position: 13
 ---
 
@@ -15,7 +15,6 @@ Here's how to do that.
 
 1. Enable HTTPS filtering in AdGuard for Android and save AdGuard's certificate to the User store (use [this instruction](../../overview#https-filtering) if needed)
 2. Go to **AdGuard app** → **Menu** (≡) → **Settings** → **Network** → **HTTPS filtering** → **Security certificate** → tap “**Copy to the system store**”
-tap “**Copy to the system store**”
 
 That is enough for older versions of Magisk.
 
@@ -52,7 +51,6 @@ In that case, proceed to steps below:
 If a new version of "AdGuard certificate" module comes out, repeat steps 3-7 to update the module.
 
 The module does its work during the system boot. If your AdGuard certificate changes, you'll have to reboot the device for the new certificate to be copied to the system store.
-you'll have to reboot the device for the new certificate to be copied to the system store.
 
 ### Bromite browser
 

--- a/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
+++ b/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
@@ -7,14 +7,14 @@ AdGuard for Android provides a feature called [HTTPS filtering](../../overview#h
 
 On a non-rooted devices CA certificates can be installed to the **User store**. Only a limited subset of apps (mostly, browsers) trust CA certificates installed to the User store, meaning HTTPS filtering won't work for apps that don't trust it.
 
-However, on rooted devices, you can install the certificate to the **System store** and allow HTTPS filtering of all other apps' traffic too. 
+However, on rooted devices, you can install the certificate to the **System store** and allow HTTPS filtering of other apps' traffic too.
 
 Here's how to do that.
 
 ## How to install AdGuard Certificate to System store (on a rooted device)
 
 1. Enable HTTPS filtering in AdGuard for Android and save AdGuard's certificate to the User store (use [this instruction](../../overview#https-filtering) if needed)
-2. Go to **AdGuard app** > **Menu** (≡) > **Settings** > **Network** > **HTTPS filtering** > **Secure certificate** >
+2. Go to **AdGuard app** → **Menu** (≡) → **Settings** → **Network** → **HTTPS filtering** → **Secure certificate** → tap “**Copy to the system store**”
 tap “**Copy to the system store**”
 
 That is enough for older versions of Magisk.
@@ -37,7 +37,7 @@ In that case, proceed to steps below:
 
 5. Download the `.zip` file (of “AdGuard Certificate” module) from the [latest release on GitHub](https://github.com/AdguardTeam/adguardcert/releases/latest/)
 
-6. Go to **Magisk** -> **Modules** -> **Install from storage** and select the downloaded `.zip` file
+6. Go to **Magisk** → **Modules** → **Install from storage** and select the downloaded `.zip` file
 
 ![Open Magisk modules *mobile](https://cdn.adtidy.org/content/kb/ad_blocker/android/solving_problems/https-certificate-for-rooted/magisk-module-4.png)
 
@@ -51,7 +51,7 @@ In that case, proceed to steps below:
 
 If a new version of "AdGuard certificate" module comes out, repeat steps 3-7 to update the module.
 
-The module does its work during the system boot. If your AdGuard certificate changes,
+The module does its work during the system boot. If your AdGuard certificate changes, you'll have to reboot the device for the new certificate to be copied to the system store.
 you'll have to reboot the device for the new certificate to be copied to the system store.
 
 ### Bromite browser

--- a/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
+++ b/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
@@ -62,5 +62,5 @@ Please note that in order for **Bromite** browser to work properly, in addition 
 
 Long story short, you will have no problems with HTTPS filtering in Chrome and Chromium-based browsers on rooted devices, if you use "AdGuard Certificate" module. 
 
-Here is a bit more detailed explanation: Chrome (and subsequently many other Chromium-based browsers) has recently started requiring CT logs for CA certs found in the **System store**. "AdGuard Certificate" module copies AdGuard's CA certificate from the **User store** to the **System store**. It also contains a Zygisk module that reverts any modifications done by Magisk for [certain browsers](./zygisk_module/jni/browsers.inc).
+Here is a bit more detailed explanation: Chrome (and subsequently many other Chromium-based browsers) has recently started requiring CT logs for CA certs found in the **System store**. "AdGuard Certificate" module copies AdGuard's CA certificate from the **User store** to the **System store**. It also contains a Zygisk module that reverts any modifications done by Magisk for [certain browsers](https://github.com/AdguardTeam/adguardcert/blob/master/zygisk_module/jni/browsers.inc).
 This way the browsers only find AdGuard’s certificate in the User store and don’t complain about the missing CT log, while other apps continue to use the same certificate from the System store.

--- a/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
+++ b/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
@@ -1,0 +1,66 @@
+---
+title: Moving certificate to system storage on rooted devices
+sidebar_position: 13
+---
+
+AdGuard for Android provides a feature called [HTTPS filtering](../../overview#https-filtering) that makes it possible to [filter encrypted HTTPS traffic](/general/https-filtering/what-is-https-filtering) on your Android device. This feature requires adding the AdGuard's CA certificate to the list of trusted certificates.
+
+On a non-rooted devices CA certificates can be installed to the **User store**. Only a limited subset of apps (mostly, browsers) trust CA certificates installed to the User store, meaning HTTPS filtering won't work for apps that don't trust it.
+
+However, on rooted devices, you can install the certificate to the **System store** and allow HTTPS filtering of all other apps' traffic too. 
+
+Here's how to do that.
+
+## How to install AdGuard Certificate to System store (on a rooted device)
+
+1. Enable HTTPS filtering in AdGuard for Android and save AdGuard's certificate to the User store (use [this instruction](../../overview#https-filtering) if needed)
+2. Go to **AdGuard app** > **Menu** (≡) > **Settings** > **Network** > **HTTPS filtering** > **Secure certificate** >
+tap “**Copy to the system store**”
+
+That is enough for older versions of Magisk.
+
+However, if you have a newer version, you will get this message:
+
+> Unable to copy the certificate to the system store. Try using “AdGuard Certificate” module.
+
+In that case, proceed to steps below:
+
+3. Go to **Magisk** -> **Settings**
+
+![Open Magisk settings *mobile](https://cdn.adtidy.org/content/kb/ad_blocker/android/solving_problems/https-certificate-for-rooted/magisk-module-1.png)
+
+4. Enable **Zygisk**
+
+![Enable Zygisk *mobile](https://cdn.adtidy.org/content/kb/ad_blocker/android/solving_problems/https-certificate-for-rooted/magisk-module-2.png)
+
+![Go back to Magisk main screen *mobile](https://cdn.adtidy.org/content/kb/ad_blocker/android/solving_problems/https-certificate-for-rooted/magisk-module-3.png)
+
+5. Download the `.zip` file (of “AdGuard Certificate” module) from the [latest release on GitHub](https://github.com/AdguardTeam/adguardcert/releases/latest/)
+
+6. Go to **Magisk** -> **Modules** -> **Install from storage** and select the downloaded `.zip` file
+
+![Open Magisk modules *mobile](https://cdn.adtidy.org/content/kb/ad_blocker/android/solving_problems/https-certificate-for-rooted/magisk-module-4.png)
+
+![Install from storage *mobile](https://cdn.adtidy.org/content/kb/ad_blocker/android/solving_problems/https-certificate-for-rooted/magisk-module-5.png)
+
+![Select AdGuard certificate module *mobile](https://cdn.adtidy.org/content/kb/ad_blocker/android/solving_problems/https-certificate-for-rooted/magisk-module-6.png)
+
+7. Reboot
+
+![Reboot the device](https://cdn.adtidy.org/content/kb/ad_blocker/android/solving_problems/https-certificate-for-rooted/magisk-module-7.png)
+
+If a new version of "AdGuard certificate" module comes out, repeat steps 3-7 to update the module.
+
+The module does its work during the system boot. If your AdGuard certificate changes,
+you'll have to reboot the device for the new certificate to be copied to the system store.
+
+### Bromite browser
+
+Please note that in order for **Bromite** browser to work properly, in addition to the steps mentioned above, you need to set flag "Allow user certificates" in `chrome://flags` to "Enabled" state.
+
+### Chrome and Chromium-based browsers
+
+Long story short, you will have no problems with HTTPS filtering in Chrome and Chromium-based browsers on rooted devices, if you use "AdGuard Certificate" module. 
+
+Here is a bit more detailed explanation: Chrome (and subsequently many other Chromium-based browsers) has recently started requiring CT logs for CA certs found in the **System store**. "AdGuard Certificate" module copies AdGuard's CA certificate from the **User store** to the **System store**. It also contains a Zygisk module that reverts any modifications done by Magisk for [certain browsers](./zygisk_module/jni/browsers.inc).
+This way the browsers only find AdGuard’s certificate in the User store and don’t complain about the missing CT log, while other apps continue to use the same certificate from the System store.

--- a/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
+++ b/docs/adguard-for-android/solving-problems/https-certificate-for-rooted.md
@@ -1,5 +1,5 @@
 ---
-title: Moving CA certificate to the System store on rooted devices
+title: Moving CA certificate to System store on rooted devices
 sidebar_position: 13
 ---
 


### PR DESCRIPTION
Add article on how to move CA certificate to System store on rooted devices, in order to enable HTTPS filtering for all apps