### PR TITLE
Rearrange modifiers

### DIFF
--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -208,12 +208,14 @@ Example:
 
 #### Basic modifiers {#basic-rules-basic-modifiers}
 
+[//]: # (Please, keep them sorted)
+
 * [`$domain`](#domain-modifier)
-* [`$to`](#to-modifier)
-* [`$third-party`](#third-party-modifier)
-* [`$popup`](#popup-modifier)
-* [`$match-case`](#match-case-modifier)
 * [`$header`](#header-modifier)
+* [`$match-case`](#match-case-modifier)
+* [`$popup`](#popup-modifier)
+* [`$third-party`](#third-party-modifier)
+* [`$to`](#to-modifier)
 
 The following modifiers are the most simple and frequently used.
 
@@ -276,80 +278,6 @@ In the following examples it is implied that requests are sent from `http://exam
 >
 > Starting with CoreLibs v1.12, the `$domain` modifier can be alternatively spelled as `$from`.
 
-#### **`$to`** {#to-modifier}
-
-`$to` limits the rule scope to requests made **to** the specified domains and their subdomains. To add multiple domains to one rule, use the `|`  character as a separator.
-
-**Examples**
-
-* `/ads$to=evil.com|evil.org` blocks any request to `evil.com` or `evil.org` and their subdomains with a path matching `/ads`.
-* `/ads$to=~not.evil.com|evil.com` blocks any request to `evil.com` and its subdomains, with a path matching `/ads`, except requests to `not.evil.com` and its subdomains.
-* `/ads$to=~good.com|~good.org` blocks any request with a path matching `/ads`, except requests to `good.com` or `good.org` and their subdomains.
-
-> **Compatibility with other modifiers**
->
-> [`$denyallow`](#denyallow-modifier) can not be used together with `$to`. It can be expressed with inverted `$to`:
-> `$denyallow=a.com|b.com` is equivalent to `$to=~a.com|~b.com`.
-
-> **Compatibility with different versions of AdGuard**
->
-> `$to` is available starting with CoreLibs v1.12.
-
-#### **`$third-party`** {#third-party-modifier}
-
-A restriction of third-party and own requests. A third-party request is a request from a different domain. For example, a request to `example.org`, from `domain.com` is a third-party request.
-
-> **Note**
->
-> To be considered as such, a third-party request should meet one of the following conditions:
-> 1. Its referrer is not a subdomain of the target domain or vice versa. For example, a request to `subdomain.example.org` from `example.org` is not a third-party request.
-> 1. Its `Sec-Fetch-Site` header is set to `cross-site`.
-If there is a `$third-party` modifier, the rule is only applied to third-party requests.
-
-**Examples**
-
-**`$third-party`:**
-
-* `||domain.com^$third-party` — this rule applies to all domains, except `domain.com` and its subdomains. A third-party request example: `http://example.org/banner.jpg`.
-
-If there is a `$~third-party` modifier, the rule is only applied to the requests that are not from third-party. Which means, they have to be sent from the same domain.
-
-**`$~third-party`:**
-
-* `||domain.com$~third-party` — this rule is applied to `domain.com`, but not to the other domains. Example of a request that is not a third-party request: `http://domain.com/icon.ico`.
-
-#### **`$popup`** {#popup-modifier}
-
-AdGuard will try to close the browser tab with any address that matches a blocking rule with this modifier. Please note that not all the tabs can be closed.
-
-> **Note**
->
-> It may not work if the popped up page is cached by the browser.
-
-**Examples**
-
-* `||domain.com^$popup` — if you try to go to `http://domain.com/` from any page in the browser, a new tab in which specified site has to be opened will be closed by this rule.
-
-> **Compatibility with different versions of AdGuard**
->
-> 1. `$popup` modifier works best in AdGuard Browser Extension.
-> 1. In AdGuard for Safari and iOS, `$popup` rules simply block the page right away.
-> 1. In AdGuard for Windows, Mac, and Android, `$popup` modifier may not detect a popup in some cases
-> and it won't be blocked. `$popup` modifier applies the `document` content type
-> with a special flag which is passed to a blocking page. Blocking page itself can do some checks
-> and close the window if it is really a popup. Otherwise, page should be loaded.
-> It can be combined with other request type modifiers, such as `$third-party` and `$important`.
-> However, the blocking page may not detect a popup in some cases, so it is recommended to use the
-> [AdGuard Popup Blocker](https://github.com/AdguardTeam/PopupBlocker) userscript instead.
-
-#### **`$match-case`** {#match-case-modifier}
-
-This modifier defines a rule which applies only to addresses that match the case. Default rules are case-insensitive.
-
-**Examples**
-
-* `*/BannerAd.gif$match-case` — this rule will block `http://example.com/BannerAd.gif`, but not `http://example.com/bannerad.gif`.
-
 #### **`$header`** {#header-modifier}
 
 The `$header` modifier allows matching the HTTP response having a specific header with (optionally) a specific value.
@@ -380,22 +308,98 @@ The modifier `":" h_value` part may be omitted. In that case the modifier matche
 * `@@||example.com^$header=set-cookie:/foo\, bar\$/` unblocks requests which responses have the `Set-Cookie` header with value matching the `foo, bar$` regular expression.
 * `@@||example.com^$header=set-cookie` unblocks requests which responses have a `Set-Cookie` header with any value.
 
+#### **`$match-case`** {#match-case-modifier}
+
+This modifier defines a rule which applies only to addresses that match the case. Default rules are case-insensitive.
+
+**Examples**
+
+* `*/BannerAd.gif$match-case` — this rule will block `http://example.com/BannerAd.gif`, but not `http://example.com/bannerad.gif`.
+
+#### **`$popup`** {#popup-modifier}
+
+AdGuard will try to close the browser tab with any address that matches a blocking rule with this modifier. Please note that not all the tabs can be closed.
+
+> **Note**
+>
+> It may not work if the popped up page is cached by the browser.
+
+**Examples**
+
+* `||domain.com^$popup` — if you try to go to `http://domain.com/` from any page in the browser, a new tab in which specified site has to be opened will be closed by this rule.
+
+> **Compatibility with different versions of AdGuard**
+>
+> 1. `$popup` modifier works best in AdGuard Browser Extension.
+> 1. In AdGuard for Safari and iOS, `$popup` rules simply block the page right away.
+> 1. In AdGuard for Windows, Mac, and Android, `$popup` modifier may not detect a popup in some cases
+> and it won't be blocked. `$popup` modifier applies the `document` content type
+> with a special flag which is passed to a blocking page. Blocking page itself can do some checks
+> and close the window if it is really a popup. Otherwise, page should be loaded.
+> It can be combined with other request type modifiers, such as `$third-party` and `$important`.
+> However, the blocking page may not detect a popup in some cases, so it is recommended to use the
+> [AdGuard Popup Blocker](https://github.com/AdguardTeam/PopupBlocker) userscript instead.
+
+#### **`$third-party`** {#third-party-modifier}
+
+A restriction of third-party and own requests. A third-party request is a request from a different domain. For example, a request to `example.org`, from `domain.com` is a third-party request.
+
+> **Note**
+>
+> To be considered as such, a third-party request should meet one of the following conditions:
+> 1. Its referrer is not a subdomain of the target domain or vice versa. For example, a request to `subdomain.example.org` from `example.org` is not a third-party request.
+> 1. Its `Sec-Fetch-Site` header is set to `cross-site`.
+If there is a `$third-party` modifier, the rule is only applied to third-party requests.
+
+**Examples**
+
+**`$third-party`:**
+
+* `||domain.com^$third-party` — this rule applies to all domains, except `domain.com` and its subdomains. A third-party request example: `http://example.org/banner.jpg`.
+
+If there is a `$~third-party` modifier, the rule is only applied to the requests that are not from third-party. Which means, they have to be sent from the same domain.
+
+**`$~third-party`:**
+
+* `||domain.com$~third-party` — this rule is applied to `domain.com`, but not to the other domains. Example of a request that is not a third-party request: `http://domain.com/icon.ico`.
+
+#### **`$to`** {#to-modifier}
+
+`$to` limits the rule scope to requests made **to** the specified domains and their subdomains. To add multiple domains to one rule, use the `|`  character as a separator.
+
+**Examples**
+
+* `/ads$to=evil.com|evil.org` blocks any request to `evil.com` or `evil.org` and their subdomains with a path matching `/ads`.
+* `/ads$to=~not.evil.com|evil.com` blocks any request to `evil.com` and its subdomains, with a path matching `/ads`, except requests to `not.evil.com` and its subdomains.
+* `/ads$to=~good.com|~good.org` blocks any request with a path matching `/ads`, except requests to `good.com` or `good.org` and their subdomains.
+
+> **Compatibility with other modifiers**
+>
+> [`$denyallow`](#denyallow-modifier) can not be used together with `$to`. It can be expressed with inverted `$to`:
+> `$denyallow=a.com|b.com` is equivalent to `$to=~a.com|~b.com`.
+
+> **Compatibility with different versions of AdGuard**
+>
+> `$to` is available starting with CoreLibs v1.12.
+
 #### Restriction by content type {#content-type-modifiers}
 
+[//]: # (Please, keep them sorted)
+
 * [`$document`](#document-modifier)
-* [`$image`](#image-modifier)
-* [`$stylesheet`](#stylesheet-modifier)
-* [`$script`](#script-modifier)
-* [`$object`](#object-modifier)
 * [`$font`](#font-modifier)
+* [`$image`](#image-modifier)
 * [`$media`](#media-modifier)
-* [`$subdocument`](#subdocument-modifier)
-* [`$ping`](#ping-modifier)
-* [`$xmlhttprequest`](#xmlhttprequest-modifier)
-* [`$websocket`](#websocket-modifier)
-* [`$other`](#other-modifier)
+* [`$object`](#object-modifier)
 * [`$object-subrequest` (deprecated)](#object-subrequest-modifier)
+* [`$other`](#other-modifier)
+* [`$ping`](#ping-modifier)
+* [`$script`](#script-modifier)
+* [`$stylesheet`](#stylesheet-modifier)
+* [`$subdocument`](#subdocument-modifier)
 * [`$webrtc` (deprecated)](#webrtc-modifier)
+* [`$websocket`](#websocket-modifier)
+* [`$xmlhttprequest`](#xmlhttprequest-modifier)
 
 There is a set of modifiers, which can be used to limit the rule's application area to certain type of content. These modifiers can also be combined to cover, for example, both images and scripts.
 
@@ -431,38 +435,32 @@ If this modifier is used with an exclusion rule (`@@`), it completely disables b
 >
 > Blocking rules with `$document` modifier are not supported by AdGuard Content Blocker.
 
-#### **`$image`** {#image-modifier}
-
-The rule corresponds to images requests.
-
-#### **`$stylesheet`** {#stylesheet-modifier}
-
-The rule corresponds to CSS files requests.
-
-#### **`$script`** {#script-modifier}
-
-The rule corresponds to script requests, e.g. javascript, vbscript.
-
-#### **`$object`** {#object-modifier}
-
-The rule corresponds to browser plugins resources, e.g. Java or Flash.
-
 #### **`$font`** {#font-modifier}
 
 The rule corresponds to requests for fonts, e.g. `.woff` filename extension.
+
+#### **`$image`** {#image-modifier}
+
+The rule corresponds to images requests.
 
 #### **`$media`** {#media-modifier}
 
 The rule corresponds to requests for media files — music and video, e.g. `.mp4` files.
 
-#### **`$subdocument`** {#subdocument-modifier}
+#### **`$object`** {#object-modifier}
 
-The rule corresponds to requests for built-in pages — HTML tags `frame` and `iframe`.
+The rule corresponds to browser plugins resources, e.g. Java or Flash.
 
-**Examples**
+#### **`$object-subrequest` (deprecated)** {#object-subrequest-modifier}
 
-* `||example.com^$subdocument` blocks built-in page requests (`frame` and `iframe`) to `example.com` and all its subdomains anywhere.
-* `||example.com^$subdocument,domain=domain.com` blocks built-in page requests (`frame` и `iframe`) to `example.com` (and its subdomains) from `domain.com` and all its subdomains.
+> **Deprecation notice**
+>
+> `$object-subrequest` modifier is deprecated and is no longer supported. Rules with it are considered as invalid.
+> The rule corresponds to requests by browser plugins (it is usually Flash).
+
+#### **`$other`** {#other-modifier}
+
+The rule applies to requests for which the type has not been determined or does not match the types listed above.
 
 #### **`$ping`** {#ping-modifier}
 
@@ -472,25 +470,22 @@ The rule corresponds to requests caused by either `navigator.sendBeacon()` or th
 >
 > AdGuard for Windows, Mac, Android often cannot accurately detect `navigator.sendBeacon()`. For reliable detection, use AdGuard Browser extension.
 
-#### **`$xmlhttprequest`** {#xmlhttprequest-modifier}
+#### **`$script`** {#script-modifier}
 
-The rule applies only to ajax requests (requests sent via javascript object `XMLHttpRequest`).
+The rule corresponds to script requests, e.g. javascript, vbscript.
 
-> **Compatibility with different versions of AdGuard**
->
-> AdGuard for Windows, Mac, Android often cannot accurately detect this type and sometimes detects it as [`$other`](#other-modifier) or [`$script`](#script-modifier). For reliable detection, use AdGuard Browser extension.
+#### **`$stylesheet`** {#stylesheet-modifier}
 
-#### **`$websocket`** {#websocket-modifier}
+The rule corresponds to CSS files requests.
 
-The rule applies only to WebSocket connections.
+#### **`$subdocument`** {#subdocument-modifier}
 
-> **Compatibility with different versions of AdGuard**
->
-> `$websocket` modifier is supported in all AdGuard products except AdGuard Content Blocker. As for AdGuard for Safari and AdGuard for iOS, it's supported on devices with macOS Monterey (version 12) and iOS 16 or higher.
+The rule corresponds to requests for built-in pages — HTML tags `frame` and `iframe`.
 
-#### **`$other`** {#other-modifier}
+**Examples**
 
-The rule applies to requests for which the type has not been determined or does not match the types listed above.
+* `||example.com^$subdocument` blocks built-in page requests (`frame` and `iframe`) to `example.com` and all its subdomains anywhere.
+* `||example.com^$subdocument,domain=domain.com` blocks built-in page requests (`frame` и `iframe`) to `example.com` (and its subdomains) from `domain.com` and all its subdomains.
 
 #### **`$webrtc` (deprecated)** {#webrtc-modifier}
 
@@ -506,39 +501,42 @@ The rule applies only to WebRTC connections.
 * `||example.com^$webrtc,domain=example.org` blocks webRTC connections to `example.com` for `example.org`.
 * `@@*$webrtc,domain=example.org` disables the RTC wrapper for `example.org`.
 
-#### **`$object-subrequest` (deprecated)** {#object-subrequest-modifier}
+#### **`$websocket`** {#websocket-modifier}
 
-> **Deprecation notice**
+The rule applies only to WebSocket connections.
+
+> **Compatibility with different versions of AdGuard**
 >
-> `$object-subrequest` modifier is deprecated and is no longer supported. Rules with it are considered as invalid.
-> The rule corresponds to requests by browser plugins (it is usually Flash).
+> `$websocket` modifier is supported in all AdGuard products except AdGuard Content Blocker. As for AdGuard for Safari and AdGuard for iOS, it's supported on devices with macOS Monterey (version 12) and iOS 16 or higher.
+
+#### **`$xmlhttprequest`** {#xmlhttprequest-modifier}
+
+The rule applies only to ajax requests (requests sent via javascript object `XMLHttpRequest`).
+
+> **Compatibility with different versions of AdGuard**
+>
+> AdGuard for Windows, Mac, Android often cannot accurately detect this type and sometimes detects it as [`$other`](#other-modifier) or [`$script`](#script-modifier). For reliable detection, use AdGuard Browser extension.
 
 #### Exception modifiers {#exception-modifiers}
 
-* [`$elemhide`](#elemhide-modifier)
+[//]: # (Please, keep them sorted)
+
 * [`$content`](#content-modifier)
-* [`$jsinject`](#jsinject-modifier)
-* [`$urlblock`](#urlblock-modifier)
+* [`$elemhide`](#elemhide-modifier)
 * [`$extension`](#extension-modifier)
-* [`$stealth`](#stealth-modifier)
+* [`$jsinject`](#jsinject-modifier)
 * [`$specifichide`](#specifichide-modifier)
+* [`$stealth`](#stealth-modifier)
+* [`$urlblock`](#urlblock-modifier)
 * [Generic rules](#exception-modifiers-generic-rules)
-  * [`$generichide`](#generichide-modifier)
   * [`$genericblock`](#genericblock-modifier)
+  * [`$generichide`](#generichide-modifier)
 
 Exception rules disable the other basic rules for the addresses to which they correspond. They begin with a `@@` mark. All the basic modifiers listed above can be applied to them and they also have a few special modifiers.
 
 > **Visual representation**
 >
 > We recommend to get acquainted with [this article](https://adblockplus.org/filter-cheatsheet#blocking), for better understanding of how exception rules should be made.
-
-#### **`$elemhide`** {#elemhide-modifier}
-
-Disables any [cosmetic rules](#cosmetic-rules) on the pages matching the rule.
-
-**Examples**
-
-* `@@||example.com^$elemhide` disables all cosmetic rules on pages at `example.com` and all subdomains.
 
 #### **`$content`** {#content-modifier}
 
@@ -548,21 +546,13 @@ Disables [HTML filtering](#html-filtering-rules) and [`$replace`](#replace-modif
 
 * `@@||example.com^$content` disables all HTML filtering rules and replace rules on pages at `example.com` and all its subdomains.
 
-#### **`$jsinject`** {#jsinject-modifier}
+#### **`$elemhide`** {#elemhide-modifier}
 
-Forbids adding of javascript code to the page. You can read about javascript rules further.
-
-**Examples**
-
-* `@@||example.com^$jsinject` disables javascript on pages at `example.com` and all subdomains.
-
-#### **`$urlblock`** {#urlblock-modifier}
-
-Disables blocking of all requests sent from the pages matching the rule.
+Disables any [cosmetic rules](#cosmetic-rules) on the pages matching the rule.
 
 **Examples**
 
-* `@@||example.com^$urlblock` — any requests sent from the pages at `example.com` and all subdomains are not going to be blocked.
+* `@@||example.com^$elemhide` disables all cosmetic rules on pages at `example.com` and all subdomains.
 
 #### **`$extension`** {#extension-modifier}
 
@@ -575,6 +565,30 @@ Disables all userscripts on the pages matching this rule.
 > **Compatibility with different versions of AdGuard**
 >
 > Only AdGuard for Windows, Mac, Android are technically capable of using rules with `$extension` modifier.
+
+#### **`$jsinject`** {#jsinject-modifier}
+
+Forbids adding of javascript code to the page. You can read about javascript rules further.
+
+**Examples**
+
+* `@@||example.com^$jsinject` disables javascript on pages at `example.com` and all subdomains.
+
+#### **`specifichide`** {#specifichide-modifier}
+
+Disables all specific element hiding and CSS rules, but not general ones. Has an opposite effect to [`$generichide`](#generichide-modifier).
+
+**Examples**
+
+* `@@||example.org^$specifichide` disables `example.org##.banner` but not `##.banner`.
+
+> **Note**
+>
+> All cosmetic rules — not just specific ones — can be disabled by [`$elemhide` modifier](#elemhide-modifier).
+
+> **Compatibility with different versions of AdGuard**
+>
+> Rules with `$specifichide` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard Browser extension for Chrome, Firefox, Edge.
 
 #### **`$stealth`** {#stealth-modifier}
 
@@ -623,21 +637,13 @@ The list of the available modifier options:
 > * Stealth Mode is available in AdGuard for Windows, Mac, Android, and AdGuard Browser extension. All other products will ignore the rules with `$stealth` modifier.
 > * `$stealth` modifier with specific options is supported by AdGuard for Windows, Mac, and Android, **running CoreLibs version 1.10 or later**.
 
-#### **`specifichide`** {#specifichide-modifier}
+#### **`$urlblock`** {#urlblock-modifier}
 
-Disables all specific element hiding and CSS rules, but not general ones. Has an opposite effect to [`$generichide`](#generichide-modifier).
+Disables blocking of all requests sent from the pages matching the rule.
 
 **Examples**
 
-* `@@||example.org^$specifichide` disables `example.org##.banner` but not `##.banner`.
-
-> **Note**
->
-> All cosmetic rules — not just specific ones — can be disabled by [`$elemhide` modifier](#elemhide-modifier).
-
-> **Compatibility with different versions of AdGuard**
->
-> Rules with `$specifichide` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard Browser extension for Chrome, Firefox, Edge.
+* `@@||example.com^$urlblock` — any requests sent from the pages at `example.com` and all subdomains are not going to be blocked.
 
 #### Generic rules {#exception-modifiers-generic-rules}
 
@@ -661,14 +667,6 @@ domain.com###banner
 ||domain.com^$domain=example.com
 ```
 
-##### **`$generichide`** {#generichide-modifier}
-
-Disables all generic [cosmetic rules](#cosmetic-rules) on pages that correspond to exception rule.
-
-**Examples**
-
-* `@@||example.com^generichide` — disables generic cosmetic rules on any pages at `example.com` and all subdomains.
-
 ##### **`$genericblock`** {#genericblock-modifier}
 
 Disables generic basic rules on pages that correspond to exception rule.
@@ -677,57 +675,76 @@ Disables generic basic rules on pages that correspond to exception rule.
 
 * `@@||example.com^$genericblock` — disables generic basic rules on any pages at `example.com` and all subdomains.
 
+##### **`$generichide`** {#generichide-modifier}
+
+Disables all generic [cosmetic rules](#cosmetic-rules) on pages that correspond to exception rule.
+
+**Examples**
+
+* `@@||example.com^generichide` — disables generic cosmetic rules on any pages at `example.com` and all subdomains.
+
 ### Advanced capabilities
 
-* [`$important`](#important-modifier)
-* [`$badfilter`](#badfilter-modifier)
-* [`$replace`](#replace-modifier)
-* [`$csp`](#csp-modifier)
-* [`$permissions`](#permissions-modifier)
+[//]: # (Please, keep them sorted)
+
 * [`$all`](#all-modifier)
-* [`$inline-script`](#inline-script-modifier)
-* [`$inline-font`](#inline-font-modifier)
-* [`$cookie`](#cookie-modifier)
-* [`$network`](#network-modifier)
 * [`$app`](#app-modifier)
+* [`$badfilter`](#badfilter-modifier)
+* [`$cookie`](#cookie-modifier)
+* [`$csp`](#csp-modifier)
+* [`$denyallow`](#denyallow-modifier)
+* [`$hls`](#hls-modifier)
+* [`$important`](#important-modifier)
+* [`$inline-font`](#inline-font-modifier)
+* [`$inline-script`](#inline-script-modifier)
+* [`$jsonprune`](#jsonprune-modifier)
 * [`$method`](#method-modifier)
+* [`$network`](#network-modifier)
+* [`$permissions`](#permissions-modifier)
 * [`$redirect`](#redirect-modifier)
 * [`$redirect-rule`](#redirect-rule-modifier)
-* [`$denyallow`](#denyallow-modifier)
+* [`$replace`](#replace-modifier)
 * [`$removeparam`](#removeparam-modifier)
 * [`$removeheader`](#removeheader-modifier)
-* [`$hls`](#hls-modifier)
-* [`$jsonprune`](#jsonprune-modifier)
 * [`noop`](#noop-modifier)
 * [`$empty` (deprecated)](#empty-modifier)
 * [`$mp4` (deprecated)](#mp4-modifier)
 
 These modifiers are able to completely change the behaviour of basic rules.
 
-#### **`$important`** {#important-modifier}
+#### **`$all`** {#all-modifier}
 
-The `$important` modifier applied to a rule increases its priority over any other rule without `$important` modifier. Even over basic exception rules.
+`$all` modifier is made of [`$document`](#document-modifier), [`$popup`](#popup-modifier), [`$csp`](#csp-modifier) modifiers. E.g. rule `||example.org^$all` is converting into such set of rules:
+```
+||example.org^$document,popup
+||example.org^$csp=script-src 'self' 'unsafe-eval' http: https: data: blob: mediastream: filesystem:
+||example.org^$csp=font-src 'self' 'unsafe-eval' http: https: data: blob: mediastream: filesystem:
+||example.org^
+```
+
+#### **`$app`** {#app-modifier}
+
+This modifier lets you narrow the rule coverage down to a specific application (or a list of applications). This might be not too important on Windows and Mac, but this is very important on mobile where some of the filtering rules must be application-specific.
+
+* Android — use the app package name, e.g. `org.example.app`.
+* Windows — use the process name, e.g. `chrome.exe`.
+* Mac — use the bundle ID or the process name, e.g. `com.google.Chrome`.
+
+> For Mac, you can find out the bundle ID or the process name of the app by viewing the respective request details in the Filtering log.
 
 **Examples**
 
-```
-! blocking rule will block all requests despite of the exception rule
-||example.org^$important
-@@||example.org^
-```
+* `||baddomain.com^$app=org.example.app` — a rule to block requests that match the specified mask, and are sent from the `org.example.app` Android app.
+* `||baddomain.com^$app=org.example.app1|org.example.app2` — the same rule, but it works for both `org.example.app1` and `org.example.app2` apps.
 
-```
-! if the exception rule also has `$important` modifier it will prevail, so no requests will not be blocked
-||example.org^$important
-@@||example.org^$important
-```
+If you want the rule not to be applied to certain apps, start the app name with `~` sign.
 
-```
-! if a document-level exception rule is applied to the document, the `$important` modifier will be ignored;
-! so if a request to `example.org` is sent from the `test.org` domain, the blocking rule will not be applied despite it has the `$important` modifier
-||example.org^$important
-@@||test.org^$document
-```
+* `||baddomain.com^$app=~org.example.app` — a rule to block requests that match the specified mask, and are sent from any app save for the `org.example.app`.
+* `||baddomain.com^$app=~org.example.app1|~org.example.app2` — same as above, but now two apps are excluded: `org.example.app1` and `org.example.app2`.
+
+> **Compatibility with different versions of AdGuard**
+>
+> Only AdGuard for Windows, Mac, Android are technically capable of using rules with `$app` modifier.
 
 #### **`$badfilter`** {#badfilter-modifier}
 
@@ -758,172 +775,6 @@ In that case, the `$badfilter` rule will disable the corresponding rule for doma
 > **Compatibility with different versions of AdGuard**
 >
 > Rules with `$badfilter` modifier are not supported by AdGuard Content Blocker.
-
-#### **`$replace`** {#replace-modifier}
-
-This modifier completely changes the rule behavior. If it is applied, the rule will not block the request. The response is going to be modified instead.
-
-> You will need some knowledge of regular expressions to use `$replace` modifier.
-
-**Features**
-
-* `$replace` rules apply to any text response, but will not apply to binary (`media`, `image`, `object`, etc).
-* `$replace` rules do not apply if the size of the original response is more than 3MB.
-* `$replace` rules have a higher priority than other basic rules (**including** exception rules). So if a request corresponds to two different rules one of which has the `$replace` modifier, this rule will be applied.
-* Document-level exception rules with `$content` or `$document` modifiers do disable `$replace` rules for requests matching them.
-* Other document-level exception rules (`$generichide`, `$elemhide` or `$jsinject` modifiers) are applied alongside `$replace` rules. It means that you can modify the page content with a `$replace` rule and disable cosmetic rules there at the same time.
-
-> `$replace` value can be empty in the case of exception rules. See examples section for further information.
-
-> **Multiple rules matching a single request**
->
-> In case if multiple `$replace` rules match a single request, we will apply each of them. **The order is defined alphabetically.**
-
-**Syntax**
-
-In general, `$replace` syntax is similar to replacement with regular expressions [in Perl](http://perldoc.perl.org/perlrequick.html#Search-and-replace).
-
-```
-replace = "/" regexp "/" replacement "/" modifiers
-```
-
-* **`regexp`** — a regular expression.
-* **`replacement`** — a string that will be used to replace the string corresponding to `regexp`.
-* **`modifiers`** — a regular expression flags. For example, `i` — insensitive search, or `s` — single-line mode.
-
-In the `$replace` value, two characters must be escaped: comma `,` and dollar sign `$`. Use backslash `\` for it. For example, an escaped comma looks like this: `\,`.
-
-**Examples**
-
-```
-||example.org^$replace=/(<VAST[\s\S]*?>)[\s\S]*<\/VAST>/\$1<\/VAST>/i
-```
-
-There are three parts in this rule:
-* `regexp` - `(<VAST(.|\s)*?>)(.|\s)*<\/VAST>`;
-* `replacement` — `\$1<\/VAST>` where `$` is escaped;
-* `modifiers` — `i` for insensitive search.
-
-You can see how this rule works here:
-http://regexr.com/3cesk
-
-**Multiple `$replace` rules**
-
-1. `||example.org^$replace=/X/Y/`
-2. `||example.org^$replace=/Z/Y/`
-3. `@@||example.org/page/*$replace=/Z/Y/`
-
-* Both rule 1 and 2 will be applied to all requests sent to `example.org`.
-* Rule 2 is disabled for requests matching `||example.org/page/`, **but rule 1 still works!**
-
-**Disabling `$replace` rules**
-
-* `@@||example.org^$replace` will disable all `$replace` rules matching `||example.org^`.
-* `@@||example.org^$document` or `@@||example.org^$content` will disable all `$replace` rules **originated from** pages of `example.org` **including the page itself**.
-
-> **Compatibility with different versions of AdGuard**
->
-> Rules with `$replace` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard Browser extension for Firefox. Such rules do not work in extensions for other browsers because they are unable to modify content on the network level.
-
-> **Restrictions**
->
-> Rules with `$replace` modifier can be used [**only in trusted filters**](#trusted-filters).
-
-#### **`$csp`** {#csp-modifier}
-
-This modifier completely changes the rule behavior. If it is applied to a rule, it will not block the matching request. The response headers are going to be modified instead.
-
-> In order to use this type of rules, it is required to have the basic understanding of the [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) security layer.
-
-For the requests matching a `$csp` rule, we will strengthen response security policy by enhancing the content security policy, similar to the content security policy of the `$csp` modifier contents. `$csp` rules are applied independently from any other rule type. Other basic rules have no influence on it **save for document-level exceptions** (see the examples section below).
-
-> **Multiple rules matching a single request**
->
-> In case if multiple `$csp` rules match a single request, we will apply each of them.
-
-**Syntax**
-
-`$csp` value syntax is similar to the Content Security Policy header syntax.
-
-`$csp` value can be empty in the case of exception rules. See examples section below.
-
-> **Limitations**
->
-> 1. There are a few characters forbidden in the `$csp` value: `,`, `$`.
-> 2. `$csp` rules support limited list of modifiers: `$domain`, `$important`, `$subdocument`.
-> 3. Rules with `report-*` directives are considered invalid.
-
-**Examples**
-
-* `||example.org^$csp=frame-src 'none'` blocks all frames on example.org and its subdomains.
-* `@@||example.org/page/*$csp=frame-src 'none'` disables all rules with the `$csp` modifier exactly matching `frame-src 'none'` on all the pages matching the rule pattern. For instance, the rule above.
-* `@@||example.org/page/*$csp` disables all the `$csp` rules on all the pages matching the rule pattern.
-* `||example.org^$csp=script-src 'self' 'unsafe-eval' http: https:` disables inline scripts on all the pages matching the rule pattern.
-* `@@||example.org^$document` or `@@||example.org^$urlblock` disables all the `$csp` rules on all the pages matching the rule pattern.
-
-> **Compatibility with different versions of AdGuard**
->
-> Rules with `$csp` modifier are not supported by AdGuard Content Blocker, AdGuard for iOS and Safari.
-
-#### **`$permissions`** {#permissions-modifier}
-
-This modifier completely changes the rule behavior. If it is applied to a rule, it will not block the matching request. The response headers are going to be modified instead.
-
-> In order to use this type of rules, it is required to have the basic understanding of the [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy) security layer.
-
-For the requests matching a `$permissions` rule, AdGuard strengthens response's permissions policy by adding additional permission policy equal to the `$permissions` modifier contents. `$permissions` rules are applied independently from any other rule type. Other basic rules have no influence on it **save for document-level exceptions** (see the examples section).
-
-> **Multiple rules matching a single request.**
->
-> In case if multiple `$permissions` rules match a single request, AdGuard will apply each of them.
-
-**Syntax**
-
-`$permissions` value syntax is similar to the `Permissions-Policy` header [syntax](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy) with one exception: comma that separates several features **MUST** be escaped — see examples below.
-The list of the available directives is available [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy#directives).
-
-`$permissions` value can be empty in the case of exception rules — see examples below.
-
-> **Limitations**
->
-> 1. Characters forbidden in the `$permissions` value: `$`;
-> 2. `$permissions` is compatible with the limited list of modifiers: `$domain`, `$important`, and `$subdocument`.
-
-**Examples**
-
-* `||example.org^$permissions=sync-xhr=()` disallows synchronous `XMLHttpRequest` requests across `example.org`.
-* `@@||example.org/page/*$permissions=sync-xhr=()` disables all rules with the `$permissions` modifier exactly matching `sync-xhr=()` on all the pages matching the rule pattern. For instance, the rule above.
-* `@@||example.org/page/*$permissions` disables all the `$permissions` rules on all the pages matching the rule pattern.
-* `$domain=example.org|example.com,permissions=oversized-images=()\, sync-script=()\, unsized-media=()` disallows oversized images, synchronous scripts and unsized media features across `example.org` and `example.com`.
-* `@@||example.org^$document` or `@@||example.org^$urlblock` disables all the `$permission` rules on all the pages matching the rule pattern.
-
-> **Compatibility with different versions of AdGuard**
->
-> Rules with the `$permissions` modifier are supported by AdGuard for Windows, Mac, and Android, **running CoreLibs version 1.11 or later**.
-
-#### **`$all`** {#all-modifier}
-
-`$all` modifier is made of [`$document`](#document-modifier), [`$popup`](#popup-modifier), [`$csp`](#csp-modifier) modifiers. E.g. rule `||example.org^$all` is converting into such set of rules:
-```
-||example.org^$document,popup
-||example.org^$csp=script-src 'self' 'unsafe-eval' http: https: data: blob: mediastream: filesystem:
-||example.org^$csp=font-src 'self' 'unsafe-eval' http: https: data: blob: mediastream: filesystem:
-||example.org^
-```
-
-#### **`$inline-script`** {#inline-script-modifier}
-
-`$inline-script` modifier is a sort of a shortcut for [`$csp`](#csp-modifier) modifier with specific value. E.g. the rule `||example.org^$inline-script` is converting into such a rule:
-```
-||example.org^$csp=script-src 'self' 'unsafe-eval' http: https: data: blob: mediastream: filesystem:
-```
-
-#### **`$inline-font`** {#inline-font-modifier}
-
-`$inline-font` modifier is a sort of a shortcut for [`$csp`](#csp-modifier) modifier with specific value. E.g. the rule `||example.org^$inline-font` is converting into such a rule:
-```
-||example.org^$csp=font-src 'self' 'unsafe-eval' http: https: data: blob: mediastream: filesystem:
-```
 
 #### **`$cookie`** {#cookie-modifier}
 
@@ -976,114 +827,41 @@ every time AdGuard encounters a cookie called `NAME` in a request to `example.or
 >
 > Rules with `$cookie` modifier are not supported by AdGuard Content Blocker, AdGuard for iOS and Safari.
 
-#### **`$network`** {#network-modifier}
+#### **`$csp`** {#csp-modifier}
 
-This is basically a Firewall-kind of rules allowing to fully block or unblock access to a specified remote address.
+This modifier completely changes the rule behavior. If it is applied to a rule, it will not block the matching request. The response headers are going to be modified instead.
 
-1. `$network` rules match **IP addresses only**! You cannot use them to block or unblock access to a domain.
-2. To match an IPv6 address, you have to use the collapsed syntax, e.g. use `[2001:4860:4860::8888]$network` instead of `[2001:4860:4860:0:0:0:0:8888]$network`.
-3. An allowlist `$network` rule makes AdGuard bypass data to the matching endpoint, e.g. there will be no further filtering at all.
-4. If the IP part starts and ends with `/` character, it is treated as a regular expression.
+> In order to use this type of rules, it is required to have the basic understanding of the [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) security layer.
 
-> We recommend to get acquainted with this [article](#regexp-support), for better understanding of regular expressions.
+For the requests matching a `$csp` rule, we will strengthen response security policy by enhancing the content security policy, similar to the content security policy of the `$csp` modifier contents. `$csp` rules are applied independently from any other rule type. Other basic rules have no influence on it **save for document-level exceptions** (see the examples section below).
 
-**Examples**
-
-* `174.129.166.49:3478^$network` blocks access to `174.129.166.49:3478` (but not to `174.129.166.49:34788`).
-* `[2001:4860:4860::8888]:443^$network` blocks access to `[2001:4860:4860::8888]:443`.
-* `174.129.166.49$network` blocks access to `174.129.166.49:*`.
-* `@@174.129.166.49$network` makes AdGuard bypass data to the endpoint. No other rules will be applied.
-* `/.+:3[0-9]{4}/$network` blocks access to any port from 30000 to 39999.
-* `/8.8.8.(:?8|4)/$network` blocks access to both `8.8.8.8` and `8.8.8.4`.
-
-> **Compatibility with different versions of AdGuard**
+> **Multiple rules matching a single request**
 >
-> Only AdGuard for Windows, Mac, Android are technically capable of using rules with `$network` modifier.
-
-#### **`$app`** {#app-modifier}
-
-This modifier lets you narrow the rule coverage down to a specific application (or a list of applications). This might be not too important on Windows and Mac, but this is very important on mobile where some of the filtering rules must be application-specific.
-
-* Android — use the app package name, e.g. `org.example.app`.
-* Windows — use the process name, e.g. `chrome.exe`.
-* Mac — use the bundle ID or the process name, e.g. `com.google.Chrome`.
-
-> For Mac, you can find out the bundle ID or the process name of the app by viewing the respective request details in the Filtering log.
-
-**Examples**
-
-* `||baddomain.com^$app=org.example.app` — a rule to block requests that match the specified mask, and are sent from the `org.example.app` Android app.
-* `||baddomain.com^$app=org.example.app1|org.example.app2` — the same rule, but it works for both `org.example.app1` and `org.example.app2` apps.
-
-If you want the rule not to be applied to certain apps, start the app name with `~` sign.
-
-* `||baddomain.com^$app=~org.example.app` — a rule to block requests that match the specified mask, and are sent from any app save for the `org.example.app`.
-* `||baddomain.com^$app=~org.example.app1|~org.example.app2` — same as above, but now two apps are excluded: `org.example.app1` and `org.example.app2`.
-
-> **Compatibility with different versions of AdGuard**
->
-> Only AdGuard for Windows, Mac, Android are technically capable of using rules with `$app` modifier.
-
-#### **`$method`** {#method-modifier}
-
-This modifier limits the rule scope to requests that use the specified set of HTTP methods. Negated methods are allowed. The methods must be specified in all lowercase characters, but are matched case-insensitively.
-
-**Examples**
-
-* `||evil.com^$method=get|head` blocks only GET and HEAD requests to `evil.com`.
-* `||evil.com^$method=~post|~put` blocks any requests except POST or PUT to `evil.com`.
-
-> **Compatibility with different versions of AdGuard**
->
-> `$method` is available starting with CoreLibs v1.12.
-
-
-#### **`$redirect`** {#redirect-modifier}
-
-AdGuard is able to redirect web requests to a local "resource".
+> In case if multiple `$csp` rules match a single request, we will apply each of them.
 
 **Syntax**
 
-AdGuard uses the same filtering rules syntax as uBlock Origin. Also, it is compatible with ABP `$rewrite=abp-resource` modifier.
+`$csp` value syntax is similar to the Content Security Policy header syntax.
 
-`$redirect` is a modifier for the [basic filtering rules](#basic-rules) so rules with this modifier support all other basic modifiers like `$domain`, `$third-party`, `$script`, etc.
+`$csp` value can be empty in the case of exception rules. See examples section below.
 
-> The value of the `$redirect` modifier must be the name of the resource that will be used for redirection.
-
-> `$redirect` rules' priority is higher than the regular basic blocking rules' priority. This means that if there is a basic blocking rule (even with `$important` modifier), `$redirect` rule will prevail over it. If there is an allowlist (`@@`) rule matching the same URL, it will disable redirecting as well (unless the `$redirect` rule is also marked as `$important`).
-
-##### Disabling `$redirect` rules
-
-
-* `||example.org/script.js$script,redirect=noopjs` — this rule redirects all requests to `example.org/script.js` to the resource named `noopjs`.
-* `||example.org/test.mp4$media,redirect=noopmp4-1s` — this rule redirects all requests to `example.org/test.mp4` to the resource named `noopmp4-1s`.
-* `@@||example.org^$redirect` will disable all `$redirect` rules for URLs that match `||example.org^`.
-* `@@||example.org^$redirect=nooptext` will disable all rules with `$redirect=nooptext` for any request that matches `||example.org^`.
-
-> More information on redirects and their usage is available [on GitHub](https://github.com/AdguardTeam/Scriptlets#redirect-resources).
-
-> **Compatibility with different versions of AdGuard**
+> **Limitations**
 >
-> Rules with `$redirect` modifier are not supported by AdGuard Content Blocker, AdGuard for iOS and Safari.
-
-#### **`$redirect-rule`** {#redirect-rule-modifier}
-
-This is basically an alias to [`$redirect`](#redirect-modifier) since it has the same "redirection" values and the logic is almost similar. The difference is that `$redirect-rule` is applied only in the case when the target request is blocked by a different basic rule.
-
-> Negating `$redirect-rule` works exactly the same way as for regular `$redirect` rules. Even more than that, `@@||example.org^$redirect` will negate both `$redirect` and `$redirect-rule` rules.
+> 1. There are a few characters forbidden in the `$csp` value: `,`, `$`.
+> 2. `$csp` rules support limited list of modifiers: `$domain`, `$important`, `$subdocument`.
+> 3. Rules with `report-*` directives are considered invalid.
 
 **Examples**
 
-```
-||example.org/script.js
-||example.org^$redirect-rule=noopjs
-```
-
-In this case, only requests to `example.org/script.js` will be "redirected" to `noopjs`. All other requests to `example.org` will be kept intact.
+* `||example.org^$csp=frame-src 'none'` blocks all frames on example.org and its subdomains.
+* `@@||example.org/page/*$csp=frame-src 'none'` disables all rules with the `$csp` modifier exactly matching `frame-src 'none'` on all the pages matching the rule pattern. For instance, the rule above.
+* `@@||example.org/page/*$csp` disables all the `$csp` rules on all the pages matching the rule pattern.
+* `||example.org^$csp=script-src 'self' 'unsafe-eval' http: https:` disables inline scripts on all the pages matching the rule pattern.
+* `@@||example.org^$document` or `@@||example.org^$urlblock` disables all the `$csp` rules on all the pages matching the rule pattern.
 
 > **Compatibility with different versions of AdGuard**
 >
-> Rules with `$redirect-rule` modifier are not supported by AdGuard Content Blocker, AdGuard for iOS and Safari.
+> Rules with `$csp` modifier are not supported by AdGuard Content Blocker, AdGuard for iOS and Safari.
 
 #### **`$denyallow`** {#denyallow-modifier}
 
@@ -1120,226 +898,6 @@ or to the combination of these three:
 > **Compatibility with different versions of AdGuard**
 >
 > Rules with `$denyallow` modifier are not supported by AdGuard Content Blocker.
-
-#### **`$removeparam`** {#removeparam-modifier}
-
-> `$queryprune` is an alias of `$removeparam`. Since `$queryprune` is deprecated, avoid using it and use `$removeparam` instead.
-
-Rules with `$removeparam` modifier are intended to strip query parameters from requests' URLs. Please note that such rules are only applied to `GET`, `HEAD`, `OPTIONS`, and [sometimes](#removeparam-modifier-compatibility) `POST` requests.
-
-> `$removeparam` rules that do not have any [content type modifiers](#content-type-modifiers) will match only requests where content type is `document`.
-
-**Syntax**
-
-**Basic syntax**
-
-* `$removeparam=param` — removes query parameter with the name `param` from URLs of any request, e.g. a request to `http://example.com/page?param=1&another=2` will be transformed to `http://example.com/page?another=2`.
-
-> `$removeparam` basic syntax is supported starting with v1.7 of [CoreLibs](https://adguard.com/en/blog/introducing-corelibs.html) and v3.6 of AdGuard Browser Extension.
-
-**Regular expressions**
-
-You can also use regular expressions to match query parameters and/or their values:
-
-* `$removeparam=/regexp/[options]` — removes query parameters that matches the `regexp` regular expression from URLs of any request. Unlike basic syntax, it means *"remove query parameters normalized to a `name=value` string which match the `regexp` regular expression"*. `[options]` here is the list of regular expression options. At the moment, the only supported option is `i` which makes matching case-insensitive.
-
-> `$removeparam` syntax for regular expressions will be supported starting with v1.8 of CoreLibs and v4.0 of AdGuard Browser Extension. For now, use the simplified version: `$removeparam=param`.
-
-> **Escaping special characters**
->
-> Do not forget to escape special characters like `,`, `/` and `$` in the regular expressions. Use `\` character for that purpose. For example, an escaped comma should look like this: `\,`.
-
-> **Note**
->
-> Regexp-type rules target both name and value of the parameter. In order to minimize the chance of mistakes, it is safer to start every regexp with `/^` unless you specifically target parameter values.
-
-> We will try to detect and ignore unescaped `$` automatically using a simple rule of thumb:
-> It is not an options delimiter if all three are true:
-> 1. It looks like `$/`;
-> 2. There is another slash character `/` to the left of it;
-> 3. There is another unescaped dollar sign `$` to the left of that slash character.
-
-**Remove all query parameters**
-
-Specify naked `$removeparam` to remove all query parameters:
-
-* `||example.org^$removeparam` — removes all query parameters from URLs matching `||example.org^`.
-
-**Inversion**
-
-Use `~` to apply inversion:
-
-* `$removeparam=~param` — removes all query parameters with the name different from `param`.
-* `$removeparam=~/regexp/` — removes all query parameters that do not match the `regexp` regular expression.
-
-**Negating `$removeparam`**
-
-This sort of rules work pretty much the same way it works with [`$csp`](#csp-modifier) and [`$redirect`](#redirect-modifier) modifiers.
-
-Use `@@` to negate `$removeparam`:
-
-* `@@||example.org^$removeparam` negates all `$removeparam` rules for URLs that match `||example.org^`.
-* `@@||example.org^$removeparam=param` negates the rule with `$removeparam=param` for any request matching `||example.org^`.
-* `@@||example.org^$removeparam=/regexp/` negates the rule with `$removeparam=/regexp/` for any request matching `||example.org^`.
-
-> **Multiple rules matching a single request**
->
-> In the case when multiple `$removeparam` rules match a single request, each of them will be applied one by one.
-
-**Examples**
-
-```
-$removeparam=/^(utm_source|utm_medium|utm_term)=/
-$removeparam=/^(utm_content|utm_campaign|utm_referrer)=/
-@@||example.com^$removeparam
-```
-
-With these rules some [UTM parameters](https://en.wikipedia.org/wiki/UTM_parameters) will be stripped out from any request, except that requests to `example.com` will not be stripped at all, e.g. `http://google.com/page?utm_source=s&utm_referrer=fb.com&utm_content=img` will be transformed to `http://google.com/page`, but `http://example.com/page?utm_source=s&utm_referrer=fb.com&utm_content=img` will not be affected by the blocking rule.
-
-* `$removeparam=utm_source` — removes `utm_source` query parameter from all requests.
-
-* `$removeparam=/utm_.*/` — removes all `utm_* query` parameters from URL queries of any request, e.g. a request to `http://example.com/page?utm_source=test` will be transformed to `http://example.com/page`.
-
-* `$removeparam=/^utm_source=campaign$/` — removes `utm_source` query parameter with the value equal to `campaign`. It does not touch other `utm_source` parameters.
-
-**Negating one `$removeparam` rule and replacing it with a different rule**
-
-```
-$removeparam=/^(gclid|yclid|fbclid)=/
-@@||example.com^$removeparam=/^(gclid|yclid|fbclid)=/
-||example.com^$removeparam=/^(yclid|fbclid)=/
-```
-
-With these rules, Google, Yandex, and Facebook Click IDs will be removed from all requests. There is one exception: Google Click ID (gclid) will not be removed from requests to example.com.
-
-**Negating `$removeparam` for all parameters**
-
-```
-$removeparam=/^(utm_source|utm_medium|utm_term)=/
-$removeparam=/^(utm_content|utm_campaign|utm_referrer)=/
-@@||example.com^$removeparam
-```
-
-With these rules, specified UTM parameters will be removed from any request save for requests to `example.org`.
-
-> **Compatibility with other modifiers**
->
-> `$removeparam` rules are compatible with [basic modifiers](#basic-rules-common-modifiers), [content type modifiers](#content-type-modifiers), and with `$important` and `$app` modifiers. The rules which have any other modifiers are considered invalid and will be discarded.
-
-> **Note**
->
-> `$removeparam` rules can also be disabled by `$document` and `$urlblock` exception rules. But basic exception rules without modifiers do not do that. For example, `@@||example.com^` will not disable `$removeparam=p` for requests to **example.com**, but `@@||example.com^$urlblock` will.
-
-> ##### **Compatibility with different versions of AdGuard** {#removeparam-modifier-compatibility}
->
-> * Rules with `$removeparam` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard browser extensions for Chrome, Firefox, Edge.
->
-> * `POST` request types are supported only by AdGuard for Windows, Mac, and Android, **running CoreLibs version 1.10 or later**.
-
-> **Restrictions**
->
-> Rules with `$removeparam` modifier can be used [**only in trusted filters**](#trusted-filters).
-
-#### **`$removeheader`** {#removeheader-modifier}
-
-Rules with `$removeheader` modifier are intended to remove headers from HTTP requests and responses. The initial motivation for this rule type is to be able to get rid of the `Refresh` header which is often used to redirect users to an undesirable location. However, this is not the only case where this modifier can be useful.
-
-Just like `$csp`, `$redirect`, `$removeparam`, and `$cookie`, this modifier exists independently, rules with it do not depend on the regular basic rules, i.e. regular exception or blocking rules will not affect it. By default, it only affects response headers. However, you can also change it to remove headers from HTTP requests as well.
-
-**Syntax**
-
-**Basic syntax**
-
-* `||example.org^$removeheader=header-name` removes a **response** header called `header-name`
-* `||example.org^$removeheader=request:header-name` removes a **request** header called `header-name`
-
-> `$removeheader` is case-insensitive, but we suggest always using lower case.
-
-**Negating `$removeheader`**
-
-This type of rules works pretty much the same way it works with `$csp` and `$redirect` modifiers.
-
-Use `@@` to negate `$removeheader`:
-
-* `@@||example.org^$removeheader` negates **all** `$removeheader` rules for URLs that match `||example.org^`.
-* `@@||example.org^$removeheader=header` negates the rule with `$removeheader=header` for any request matching `||example.org^`.
-
-> `$removeheader` rules can also be disabled by `$document` and `$urlblock` exception rules. But basic exception rules without modifiers will not do that. For example, `@@||example.com^` will not disable `$removeheader=p` for requests to `example.com`, but `@@||example.com^$urlblock` will.
-
-> **Multiple rules matching a single request**
->
-> In case of multiple `$removeheader` rules matching a single request, we will apply each of them one by one.
-
-> **Restrictions**
->
-> 1. This type of rules can be used [**only in trusted filters**](#trusted-filters).
->
-> 2. In order to avoid compromising the security `$removeheader` cannot remove headers from the list below:
->   * `access-control-allow-origin`
->   * `access-control-allow-credentials`
->   * `access-control-allow-headers`
->   * `access-control-allow-methods`
->   * `access-control-expose-headers`
->   * `access-control-max-age`
->   * `access-control-request-headers`
->   * `access-control-request-method`
->   * `origin`
->   * `timing-allow-origin`
->   * `allow`
->   * `cross-origin-embedder-policy`
->   * `cross-origin-opener-policy`
->   * `cross-origin-resource-policy`
->   * `content-security-policy`
->   * `content-security-policy-report-only`
->   * `expect-ct`
->   * `feature-policy`
->   * `origin-isolation`
->   * `strict-transport-security`
->   * `upgrade-insecure-requests`
->   * `x-content-type-options`
->   * `x-download-options`
->   * `x-frame-options`
->   * `x-permitted-cross-domain-policies`
->   * `x-powered-by`
->   * `x-xss-protection`
->   * `public-key-pins`
->   * `public-key-pins-report-only`
->   * `sec-websocket-key`
->   * `sec-websocket-extensions`
->   * `sec-websocket-accept`
->   * `sec-websocket-protocol`
->   * `sec-websocket-version`
->   * `p3p`
->   * `sec-fetch-mode`
->   * `sec-fetch-dest`
->   * `sec-fetch-site`
->   * `sec-fetch-user`
->   * `referrer-policy`
->   * `content-type`
->   * `content-length`
->   * `accept`
->   * `accept-encoding`
->   * `host`
->   * `connection`
->   * `transfer-encoding`
->   * `upgrade`
->
-> 3. `$removeheader` rules are not compatible with any other modifiers except `$domain`, `$third-party`, `$app`, `$important`, `$match-case`, and [content type modifiers](#content-type-modifiers), e.g. `$script`, `$stylesheet`, etc. The rules which have any other modifiers are considered invalid and will be discarded.
-
-**Examples**
-
-* `||example.org^$removeheader=refresh` removes `Refresh` header from all HTTP responses returned by `example.org` and its subdomains.
-* `||example.org^$removeheader=request:x-client-data` removes `X-Client-Data` header from all HTTP requests.
-* Next block of rules removes `Refresh` and `Location` headers from all HTTP responses returned by `example.org` save for requests to `example.org/path/*`, for which no headers will be removed:
-  ```
-  ||example.org^$removeheader=refresh
-  ||example.org^$removeheader=location
-  @@||example.org/path/$removeheader
-  ```
-
-> **Compatibility with different versions of AdGuard**
->
-> Rules with `$removeheader` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard Browser extension for Chrome, Firefox, Edge.
 
 #### **`$hls`** {#hls-modifier}
 
@@ -1454,6 +1012,45 @@ preroll.ts
 > **Compatibility with different versions of AdGuard**
 >
 > Rules with the `$hls` modifier are supported by AdGuard for Windows, Mac, and Android, **running CoreLibs version 1.10 or later**.
+
+#### **`$important`** {#important-modifier}
+
+The `$important` modifier applied to a rule increases its priority over any other rule without `$important` modifier. Even over basic exception rules.
+
+**Examples**
+
+```
+! blocking rule will block all requests despite of the exception rule
+||example.org^$important
+@@||example.org^
+```
+
+```
+! if the exception rule also has `$important` modifier it will prevail, so no requests will not be blocked
+||example.org^$important
+@@||example.org^$important
+```
+
+```
+! if a document-level exception rule is applied to the document, the `$important` modifier will be ignored;
+! so if a request to `example.org` is sent from the `test.org` domain, the blocking rule will not be applied despite it has the `$important` modifier
+||example.org^$important
+@@||test.org^$document
+```
+
+#### **`$inline-script`** {#inline-script-modifier}
+
+`$inline-script` modifier is a sort of a shortcut for [`$csp`](#csp-modifier) modifier with specific value. E.g. the rule `||example.org^$inline-script` is converting into such a rule:
+```
+||example.org^$csp=script-src 'self' 'unsafe-eval' http: https: data: blob: mediastream: filesystem:
+```
+
+#### **`$inline-font`** {#inline-font-modifier}
+
+`$inline-font` modifier is a sort of a shortcut for [`$csp`](#csp-modifier) modifier with specific value. E.g. the rule `||example.org^$inline-font` is converting into such a rule:
+```
+||example.org^$csp=font-src 'self' 'unsafe-eval' http: https: data: blob: mediastream: filesystem:
+```
 
 #### **`$jsonprune`** {#jsonprune-modifier}
 
@@ -1680,6 +1277,416 @@ Basic URL exceptions shall not disable rules with `$jsonprune` modifier. They ca
 ```
 
 </details>
+
+#### **`$method`** {#method-modifier}
+
+This modifier limits the rule scope to requests that use the specified set of HTTP methods. Negated methods are allowed. The methods must be specified in all lowercase characters, but are matched case-insensitively.
+
+**Examples**
+
+* `||evil.com^$method=get|head` blocks only GET and HEAD requests to `evil.com`.
+* `||evil.com^$method=~post|~put` blocks any requests except POST or PUT to `evil.com`.
+
+> **Compatibility with different versions of AdGuard**
+>
+> `$method` is available starting with CoreLibs v1.12.
+
+#### **`$network`** {#network-modifier}
+
+This is basically a Firewall-kind of rules allowing to fully block or unblock access to a specified remote address.
+
+1. `$network` rules match **IP addresses only**! You cannot use them to block or unblock access to a domain.
+2. To match an IPv6 address, you have to use the collapsed syntax, e.g. use `[2001:4860:4860::8888]$network` instead of `[2001:4860:4860:0:0:0:0:8888]$network`.
+3. An allowlist `$network` rule makes AdGuard bypass data to the matching endpoint, e.g. there will be no further filtering at all.
+4. If the IP part starts and ends with `/` character, it is treated as a regular expression.
+
+> We recommend to get acquainted with this [article](#regexp-support), for better understanding of regular expressions.
+
+**Examples**
+
+* `174.129.166.49:3478^$network` blocks access to `174.129.166.49:3478` (but not to `174.129.166.49:34788`).
+* `[2001:4860:4860::8888]:443^$network` blocks access to `[2001:4860:4860::8888]:443`.
+* `174.129.166.49$network` blocks access to `174.129.166.49:*`.
+* `@@174.129.166.49$network` makes AdGuard bypass data to the endpoint. No other rules will be applied.
+* `/.+:3[0-9]{4}/$network` blocks access to any port from 30000 to 39999.
+* `/8.8.8.(:?8|4)/$network` blocks access to both `8.8.8.8` and `8.8.8.4`.
+
+> **Compatibility with different versions of AdGuard**
+>
+> Only AdGuard for Windows, Mac, Android are technically capable of using rules with `$network` modifier.
+
+#### **`$permissions`** {#permissions-modifier}
+
+This modifier completely changes the rule behavior. If it is applied to a rule, it will not block the matching request. The response headers are going to be modified instead.
+
+> In order to use this type of rules, it is required to have the basic understanding of the [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy) security layer.
+
+For the requests matching a `$permissions` rule, AdGuard strengthens response's permissions policy by adding additional permission policy equal to the `$permissions` modifier contents. `$permissions` rules are applied independently from any other rule type. Other basic rules have no influence on it **save for document-level exceptions** (see the examples section).
+
+> **Multiple rules matching a single request.**
+>
+> In case if multiple `$permissions` rules match a single request, AdGuard will apply each of them.
+
+**Syntax**
+
+`$permissions` value syntax is similar to the `Permissions-Policy` header [syntax](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy) with one exception: comma that separates several features **MUST** be escaped — see examples below.
+The list of the available directives is available [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy#directives).
+
+`$permissions` value can be empty in the case of exception rules — see examples below.
+
+> **Limitations**
+>
+> 1. Characters forbidden in the `$permissions` value: `$`;
+> 2. `$permissions` is compatible with the limited list of modifiers: `$domain`, `$important`, and `$subdocument`.
+
+**Examples**
+
+* `||example.org^$permissions=sync-xhr=()` disallows synchronous `XMLHttpRequest` requests across `example.org`.
+* `@@||example.org/page/*$permissions=sync-xhr=()` disables all rules with the `$permissions` modifier exactly matching `sync-xhr=()` on all the pages matching the rule pattern. For instance, the rule above.
+* `@@||example.org/page/*$permissions` disables all the `$permissions` rules on all the pages matching the rule pattern.
+* `$domain=example.org|example.com,permissions=oversized-images=()\, sync-script=()\, unsized-media=()` disallows oversized images, synchronous scripts and unsized media features across `example.org` and `example.com`.
+* `@@||example.org^$document` or `@@||example.org^$urlblock` disables all the `$permission` rules on all the pages matching the rule pattern.
+
+> **Compatibility with different versions of AdGuard**
+>
+> Rules with the `$permissions` modifier are supported by AdGuard for Windows, Mac, and Android, **running CoreLibs version 1.11 or later**.
+
+#### **`$redirect`** {#redirect-modifier}
+
+AdGuard is able to redirect web requests to a local "resource".
+
+**Syntax**
+
+AdGuard uses the same filtering rules syntax as uBlock Origin. Also, it is compatible with ABP `$rewrite=abp-resource` modifier.
+
+`$redirect` is a modifier for the [basic filtering rules](#basic-rules) so rules with this modifier support all other basic modifiers like `$domain`, `$third-party`, `$script`, etc.
+
+> The value of the `$redirect` modifier must be the name of the resource that will be used for redirection.
+
+> `$redirect` rules' priority is higher than the regular basic blocking rules' priority. This means that if there is a basic blocking rule (even with `$important` modifier), `$redirect` rule will prevail over it. If there is an allowlist (`@@`) rule matching the same URL, it will disable redirecting as well (unless the `$redirect` rule is also marked as `$important`).
+
+##### Disabling `$redirect` rules
+
+
+* `||example.org/script.js$script,redirect=noopjs` — this rule redirects all requests to `example.org/script.js` to the resource named `noopjs`.
+* `||example.org/test.mp4$media,redirect=noopmp4-1s` — this rule redirects all requests to `example.org/test.mp4` to the resource named `noopmp4-1s`.
+* `@@||example.org^$redirect` will disable all `$redirect` rules for URLs that match `||example.org^`.
+* `@@||example.org^$redirect=nooptext` will disable all rules with `$redirect=nooptext` for any request that matches `||example.org^`.
+
+> More information on redirects and their usage is available [on GitHub](https://github.com/AdguardTeam/Scriptlets#redirect-resources).
+
+> **Compatibility with different versions of AdGuard**
+>
+> Rules with `$redirect` modifier are not supported by AdGuard Content Blocker, AdGuard for iOS and Safari.
+
+#### **`$redirect-rule`** {#redirect-rule-modifier}
+
+This is basically an alias to [`$redirect`](#redirect-modifier) since it has the same "redirection" values and the logic is almost similar. The difference is that `$redirect-rule` is applied only in the case when the target request is blocked by a different basic rule.
+
+> Negating `$redirect-rule` works exactly the same way as for regular `$redirect` rules. Even more than that, `@@||example.org^$redirect` will negate both `$redirect` and `$redirect-rule` rules.
+
+**Examples**
+
+```
+||example.org/script.js
+||example.org^$redirect-rule=noopjs
+```
+
+In this case, only requests to `example.org/script.js` will be "redirected" to `noopjs`. All other requests to `example.org` will be kept intact.
+
+> **Compatibility with different versions of AdGuard**
+>
+> Rules with `$redirect-rule` modifier are not supported by AdGuard Content Blocker, AdGuard for iOS and Safari.
+
+#### **`$removeheader`** {#removeheader-modifier}
+
+Rules with `$removeheader` modifier are intended to remove headers from HTTP requests and responses. The initial motivation for this rule type is to be able to get rid of the `Refresh` header which is often used to redirect users to an undesirable location. However, this is not the only case where this modifier can be useful.
+
+Just like `$csp`, `$redirect`, `$removeparam`, and `$cookie`, this modifier exists independently, rules with it do not depend on the regular basic rules, i.e. regular exception or blocking rules will not affect it. By default, it only affects response headers. However, you can also change it to remove headers from HTTP requests as well.
+
+**Syntax**
+
+**Basic syntax**
+
+* `||example.org^$removeheader=header-name` removes a **response** header called `header-name`
+* `||example.org^$removeheader=request:header-name` removes a **request** header called `header-name`
+
+> `$removeheader` is case-insensitive, but we suggest always using lower case.
+
+**Negating `$removeheader`**
+
+This type of rules works pretty much the same way it works with `$csp` and `$redirect` modifiers.
+
+Use `@@` to negate `$removeheader`:
+
+* `@@||example.org^$removeheader` negates **all** `$removeheader` rules for URLs that match `||example.org^`.
+* `@@||example.org^$removeheader=header` negates the rule with `$removeheader=header` for any request matching `||example.org^`.
+
+> `$removeheader` rules can also be disabled by `$document` and `$urlblock` exception rules. But basic exception rules without modifiers will not do that. For example, `@@||example.com^` will not disable `$removeheader=p` for requests to `example.com`, but `@@||example.com^$urlblock` will.
+
+> **Multiple rules matching a single request**
+>
+> In case of multiple `$removeheader` rules matching a single request, we will apply each of them one by one.
+
+> **Restrictions**
+>
+> 1. This type of rules can be used [**only in trusted filters**](#trusted-filters).
+>
+> 2. In order to avoid compromising the security `$removeheader` cannot remove headers from the list below:
+>   * `access-control-allow-origin`
+>   * `access-control-allow-credentials`
+>   * `access-control-allow-headers`
+>   * `access-control-allow-methods`
+>   * `access-control-expose-headers`
+>   * `access-control-max-age`
+>   * `access-control-request-headers`
+>   * `access-control-request-method`
+>   * `origin`
+>   * `timing-allow-origin`
+>   * `allow`
+>   * `cross-origin-embedder-policy`
+>   * `cross-origin-opener-policy`
+>   * `cross-origin-resource-policy`
+>   * `content-security-policy`
+>   * `content-security-policy-report-only`
+>   * `expect-ct`
+>   * `feature-policy`
+>   * `origin-isolation`
+>   * `strict-transport-security`
+>   * `upgrade-insecure-requests`
+>   * `x-content-type-options`
+>   * `x-download-options`
+>   * `x-frame-options`
+>   * `x-permitted-cross-domain-policies`
+>   * `x-powered-by`
+>   * `x-xss-protection`
+>   * `public-key-pins`
+>   * `public-key-pins-report-only`
+>   * `sec-websocket-key`
+>   * `sec-websocket-extensions`
+>   * `sec-websocket-accept`
+>   * `sec-websocket-protocol`
+>   * `sec-websocket-version`
+>   * `p3p`
+>   * `sec-fetch-mode`
+>   * `sec-fetch-dest`
+>   * `sec-fetch-site`
+>   * `sec-fetch-user`
+>   * `referrer-policy`
+>   * `content-type`
+>   * `content-length`
+>   * `accept`
+>   * `accept-encoding`
+>   * `host`
+>   * `connection`
+>   * `transfer-encoding`
+>   * `upgrade`
+>
+> 3. `$removeheader` rules are not compatible with any other modifiers except `$domain`, `$third-party`, `$app`, `$important`, `$match-case`, and [content type modifiers](#content-type-modifiers), e.g. `$script`, `$stylesheet`, etc. The rules which have any other modifiers are considered invalid and will be discarded.
+
+**Examples**
+
+* `||example.org^$removeheader=refresh` removes `Refresh` header from all HTTP responses returned by `example.org` and its subdomains.
+* `||example.org^$removeheader=request:x-client-data` removes `X-Client-Data` header from all HTTP requests.
+* Next block of rules removes `Refresh` and `Location` headers from all HTTP responses returned by `example.org` save for requests to `example.org/path/*`, for which no headers will be removed:
+  ```
+  ||example.org^$removeheader=refresh
+  ||example.org^$removeheader=location
+  @@||example.org/path/$removeheader
+  ```
+
+> **Compatibility with different versions of AdGuard**
+>
+> Rules with `$removeheader` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard Browser extension for Chrome, Firefox, Edge.
+
+#### **`$removeparam`** {#removeparam-modifier}
+
+> `$queryprune` is an alias of `$removeparam`. Since `$queryprune` is deprecated, avoid using it and use `$removeparam` instead.
+
+Rules with `$removeparam` modifier are intended to strip query parameters from requests' URLs. Please note that such rules are only applied to `GET`, `HEAD`, `OPTIONS`, and [sometimes](#removeparam-modifier-compatibility) `POST` requests.
+
+> `$removeparam` rules that do not have any [content type modifiers](#content-type-modifiers) will match only requests where content type is `document`.
+
+**Syntax**
+
+**Basic syntax**
+
+* `$removeparam=param` — removes query parameter with the name `param` from URLs of any request, e.g. a request to `http://example.com/page?param=1&another=2` will be transformed to `http://example.com/page?another=2`.
+
+> `$removeparam` basic syntax is supported starting with v1.7 of [CoreLibs](https://adguard.com/en/blog/introducing-corelibs.html) and v3.6 of AdGuard Browser Extension.
+
+**Regular expressions**
+
+You can also use regular expressions to match query parameters and/or their values:
+
+* `$removeparam=/regexp/[options]` — removes query parameters that matches the `regexp` regular expression from URLs of any request. Unlike basic syntax, it means *"remove query parameters normalized to a `name=value` string which match the `regexp` regular expression"*. `[options]` here is the list of regular expression options. At the moment, the only supported option is `i` which makes matching case-insensitive.
+
+> `$removeparam` syntax for regular expressions will be supported starting with v1.8 of CoreLibs and v4.0 of AdGuard Browser Extension. For now, use the simplified version: `$removeparam=param`.
+
+> **Escaping special characters**
+>
+> Do not forget to escape special characters like `,`, `/` and `$` in the regular expressions. Use `\` character for that purpose. For example, an escaped comma should look like this: `\,`.
+
+> **Note**
+>
+> Regexp-type rules target both name and value of the parameter. In order to minimize the chance of mistakes, it is safer to start every regexp with `/^` unless you specifically target parameter values.
+
+> We will try to detect and ignore unescaped `$` automatically using a simple rule of thumb:
+> It is not an options delimiter if all three are true:
+> 1. It looks like `$/`;
+> 2. There is another slash character `/` to the left of it;
+> 3. There is another unescaped dollar sign `$` to the left of that slash character.
+
+**Remove all query parameters**
+
+Specify naked `$removeparam` to remove all query parameters:
+
+* `||example.org^$removeparam` — removes all query parameters from URLs matching `||example.org^`.
+
+**Inversion**
+
+Use `~` to apply inversion:
+
+* `$removeparam=~param` — removes all query parameters with the name different from `param`.
+* `$removeparam=~/regexp/` — removes all query parameters that do not match the `regexp` regular expression.
+
+**Negating `$removeparam`**
+
+This sort of rules work pretty much the same way it works with [`$csp`](#csp-modifier) and [`$redirect`](#redirect-modifier) modifiers.
+
+Use `@@` to negate `$removeparam`:
+
+* `@@||example.org^$removeparam` negates all `$removeparam` rules for URLs that match `||example.org^`.
+* `@@||example.org^$removeparam=param` negates the rule with `$removeparam=param` for any request matching `||example.org^`.
+* `@@||example.org^$removeparam=/regexp/` negates the rule with `$removeparam=/regexp/` for any request matching `||example.org^`.
+
+> **Multiple rules matching a single request**
+>
+> In the case when multiple `$removeparam` rules match a single request, each of them will be applied one by one.
+
+**Examples**
+
+```
+$removeparam=/^(utm_source|utm_medium|utm_term)=/
+$removeparam=/^(utm_content|utm_campaign|utm_referrer)=/
+@@||example.com^$removeparam
+```
+
+With these rules some [UTM parameters](https://en.wikipedia.org/wiki/UTM_parameters) will be stripped out from any request, except that requests to `example.com` will not be stripped at all, e.g. `http://google.com/page?utm_source=s&utm_referrer=fb.com&utm_content=img` will be transformed to `http://google.com/page`, but `http://example.com/page?utm_source=s&utm_referrer=fb.com&utm_content=img` will not be affected by the blocking rule.
+
+* `$removeparam=utm_source` — removes `utm_source` query parameter from all requests.
+
+* `$removeparam=/utm_.*/` — removes all `utm_* query` parameters from URL queries of any request, e.g. a request to `http://example.com/page?utm_source=test` will be transformed to `http://example.com/page`.
+
+* `$removeparam=/^utm_source=campaign$/` — removes `utm_source` query parameter with the value equal to `campaign`. It does not touch other `utm_source` parameters.
+
+**Negating one `$removeparam` rule and replacing it with a different rule**
+
+```
+$removeparam=/^(gclid|yclid|fbclid)=/
+@@||example.com^$removeparam=/^(gclid|yclid|fbclid)=/
+||example.com^$removeparam=/^(yclid|fbclid)=/
+```
+
+With these rules, Google, Yandex, and Facebook Click IDs will be removed from all requests. There is one exception: Google Click ID (gclid) will not be removed from requests to example.com.
+
+**Negating `$removeparam` for all parameters**
+
+```
+$removeparam=/^(utm_source|utm_medium|utm_term)=/
+$removeparam=/^(utm_content|utm_campaign|utm_referrer)=/
+@@||example.com^$removeparam
+```
+
+With these rules, specified UTM parameters will be removed from any request save for requests to `example.org`.
+
+> **Compatibility with other modifiers**
+>
+> `$removeparam` rules are compatible with [basic modifiers](#basic-rules-common-modifiers), [content type modifiers](#content-type-modifiers), and with `$important` and `$app` modifiers. The rules which have any other modifiers are considered invalid and will be discarded.
+
+> **Note**
+>
+> `$removeparam` rules can also be disabled by `$document` and `$urlblock` exception rules. But basic exception rules without modifiers do not do that. For example, `@@||example.com^` will not disable `$removeparam=p` for requests to **example.com**, but `@@||example.com^$urlblock` will.
+
+> ##### **Compatibility with different versions of AdGuard** {#removeparam-modifier-compatibility}
+>
+> * Rules with `$removeparam` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard browser extensions for Chrome, Firefox, Edge.
+>
+> * `POST` request types are supported only by AdGuard for Windows, Mac, and Android, **running CoreLibs version 1.10 or later**.
+
+> **Restrictions**
+>
+> Rules with `$removeparam` modifier can be used [**only in trusted filters**](#trusted-filters).
+
+#### **`$replace`** {#replace-modifier}
+
+This modifier completely changes the rule behavior. If it is applied, the rule will not block the request. The response is going to be modified instead.
+
+> You will need some knowledge of regular expressions to use `$replace` modifier.
+
+**Features**
+
+* `$replace` rules apply to any text response, but will not apply to binary (`media`, `image`, `object`, etc).
+* `$replace` rules do not apply if the size of the original response is more than 3MB.
+* `$replace` rules have a higher priority than other basic rules (**including** exception rules). So if a request corresponds to two different rules one of which has the `$replace` modifier, this rule will be applied.
+* Document-level exception rules with `$content` or `$document` modifiers do disable `$replace` rules for requests matching them.
+* Other document-level exception rules (`$generichide`, `$elemhide` or `$jsinject` modifiers) are applied alongside `$replace` rules. It means that you can modify the page content with a `$replace` rule and disable cosmetic rules there at the same time.
+
+> `$replace` value can be empty in the case of exception rules. See examples section for further information.
+
+> **Multiple rules matching a single request**
+>
+> In case if multiple `$replace` rules match a single request, we will apply each of them. **The order is defined alphabetically.**
+
+**Syntax**
+
+In general, `$replace` syntax is similar to replacement with regular expressions [in Perl](http://perldoc.perl.org/perlrequick.html#Search-and-replace).
+
+```
+replace = "/" regexp "/" replacement "/" modifiers
+```
+
+* **`regexp`** — a regular expression.
+* **`replacement`** — a string that will be used to replace the string corresponding to `regexp`.
+* **`modifiers`** — a regular expression flags. For example, `i` — insensitive search, or `s` — single-line mode.
+
+In the `$replace` value, two characters must be escaped: comma `,` and dollar sign `$`. Use backslash `\` for it. For example, an escaped comma looks like this: `\,`.
+
+**Examples**
+
+```
+||example.org^$replace=/(<VAST[\s\S]*?>)[\s\S]*<\/VAST>/\$1<\/VAST>/i
+```
+
+There are three parts in this rule:
+* `regexp` - `(<VAST(.|\s)*?>)(.|\s)*<\/VAST>`;
+* `replacement` — `\$1<\/VAST>` where `$` is escaped;
+* `modifiers` — `i` for insensitive search.
+
+You can see how this rule works here:
+http://regexr.com/3cesk
+
+**Multiple `$replace` rules**
+
+1. `||example.org^$replace=/X/Y/`
+2. `||example.org^$replace=/Z/Y/`
+3. `@@||example.org/page/*$replace=/Z/Y/`
+
+* Both rule 1 and 2 will be applied to all requests sent to `example.org`.
+* Rule 2 is disabled for requests matching `||example.org/page/`, **but rule 1 still works!**
+
+**Disabling `$replace` rules**
+
+* `@@||example.org^$replace` will disable all `$replace` rules matching `||example.org^`.
+* `@@||example.org^$document` or `@@||example.org^$content` will disable all `$replace` rules **originated from** pages of `example.org` **including the page itself**.
+
+> **Compatibility with different versions of AdGuard**
+>
+> Rules with `$replace` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard Browser extension for Firefox. Such rules do not work in extensions for other browsers because they are unable to modify content on the network level.
+
+> **Restrictions**
+>
+> Rules with `$replace` modifier can be used [**only in trusted filters**](#trusted-filters).
 
 #### **`noop`** {#noop-modifier}
 
@@ -2722,6 +2729,8 @@ Learn more about [how to debug scriptlets](#debug-scriptlets).
 More information about trusted scriptlets can be found [on GitHub](https://github.com/AdguardTeam/Scriptlets#trusted-scriptlets).
 
 ## Modifiers for non-basic type of rules
+
+[//]: # (Please, keep them sorted)
 
 * [`$app`](#non-basic-app-modifier)
 * [`$domain`](#non-basic-domain-modifier)

--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -895,7 +895,7 @@ every time AdGuard encounters a cookie called `NAME` in a request to `example.or
 
 > **Limitations**
 >
-> `$cookie` rules support a limited list of modifiers: `$domain`, `$~domain`, `$important`, `$third-party`, `$~third-party`.
+> `$cookie` rules support a limited list of modifiers: `$domain`, `$~domain`, `$important`, `$third-party`, and `$~third-party`.
 
 > **Compatibility with different versions of AdGuard**
 >

--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -486,7 +486,7 @@ If there is a `$~third-party` modifier, the rule is only applied to the requests
 
 #### Restriction by content type {#content-type-modifiers}
 
-[//]: # (Please, keep them sorted)
+[//]: # (Please keep them sorted)
 
 * [`$document`](#document-modifier)
 * [`$font`](#font-modifier)
@@ -621,7 +621,7 @@ The rule applies only to WebRTC connections.
 
 #### Exception modifiers {#exception-modifiers}
 
-[//]: # (Please, keep them sorted)
+[//]: # (Please keep them sorted)
 
 * [`$content`](#content-modifier)
 * [`$elemhide`](#elemhide-modifier)
@@ -787,7 +787,7 @@ Disables all generic [cosmetic rules](#cosmetic-rules) on pages that correspond 
 
 ### Advanced capabilities
 
-[//]: # (Please, keep them sorted)
+[//]: # (Please keep them sorted)
 
 * [`$all`](#all-modifier)
 * [`$badfilter`](#badfilter-modifier)
@@ -2730,7 +2730,7 @@ More information about trusted scriptlets can be found [on GitHub](https://githu
 
 ## Modifiers for non-basic type of rules
 
-[//]: # (Please, keep them sorted)
+[//]: # (Please keep them sorted)
 
 * [`$app`](#non-basic-app-modifier)
 * [`$domain`](#non-basic-domain-modifier)

--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -208,7 +208,7 @@ Example:
 
 #### Basic modifiers {#basic-rules-basic-modifiers}
 
-[//]: # (Please, keep them sorted)
+[//]: # (Please keep them sorted)
 
 * [`$app`](#app-modifier)
 * [`$denyallow`](#denyallow-modifier)

--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -493,15 +493,15 @@ If there is a `$~third-party` modifier, the rule is only applied to the requests
 * [`$image`](#image-modifier)
 * [`$media`](#media-modifier)
 * [`$object`](#object-modifier)
-* [`$object-subrequest` (deprecated)](#object-subrequest-modifier)
 * [`$other`](#other-modifier)
 * [`$ping`](#ping-modifier)
 * [`$script`](#script-modifier)
 * [`$stylesheet`](#stylesheet-modifier)
 * [`$subdocument`](#subdocument-modifier)
-* [`$webrtc` (deprecated)](#webrtc-modifier)
 * [`$websocket`](#websocket-modifier)
 * [`$xmlhttprequest`](#xmlhttprequest-modifier)
+* [`$object-subrequest` (deprecated)](#object-subrequest-modifier)
+* [`$webrtc` (deprecated)](#webrtc-modifier)
 
 There is a set of modifiers, which can be used to limit the rule's application area to certain type of content. These modifiers can also be combined to cover, for example, both images and scripts.
 
@@ -553,13 +553,6 @@ The rule corresponds to requests for media files — music and video, e.g. `.mp4
 
 The rule corresponds to browser plugins resources, e.g. Java or Flash.
 
-#### **`$object-subrequest` (deprecated)** {#object-subrequest-modifier}
-
-> **Deprecation notice**
->
-> `$object-subrequest` modifier is deprecated and is no longer supported. Rules with it are considered as invalid.
-> The rule corresponds to requests by browser plugins (it is usually Flash).
-
 #### **`$other`** {#other-modifier}
 
 The rule applies to requests for which the type has not been determined or does not match the types listed above.
@@ -589,20 +582,6 @@ The rule corresponds to requests for built-in pages — HTML tags `frame` and `i
 * `||example.com^$subdocument` blocks built-in page requests (`frame` and `iframe`) to `example.com` and all its subdomains anywhere.
 * `||example.com^$subdocument,domain=domain.com` blocks built-in page requests (`frame` и `iframe`) to `example.com` (and its subdomains) from `domain.com` and all its subdomains.
 
-#### **`$webrtc` (deprecated)** {#webrtc-modifier}
-
-> **Deprecation notice**
->
-> This modifier is deprecated and is no longer supported. Rules with it are considered as invalid.
-> If you need to suppress WebRTC, consider using the `nowebrtc` [scriptlet](#scriptlets).
-
-The rule applies only to WebRTC connections.
-
-**Examples**
-
-* `||example.com^$webrtc,domain=example.org` blocks webRTC connections to `example.com` for `example.org`.
-* `@@*$webrtc,domain=example.org` disables the RTC wrapper for `example.org`.
-
 #### **`$websocket`** {#websocket-modifier}
 
 The rule applies only to WebSocket connections.
@@ -618,6 +597,27 @@ The rule applies only to ajax requests (requests sent via javascript object `XML
 > **Compatibility with different versions of AdGuard**
 >
 > AdGuard for Windows, Mac, Android often cannot accurately detect this type and sometimes detects it as [`$other`](#other-modifier) or [`$script`](#script-modifier). For reliable detection, use AdGuard Browser extension.
+
+#### **`$object-subrequest` (deprecated)** {#object-subrequest-modifier}
+
+> **Deprecation notice**
+>
+> `$object-subrequest` modifier is deprecated and is no longer supported. Rules with it are considered as invalid.
+> The rule corresponds to requests by browser plugins (it is usually Flash).
+
+#### **`$webrtc` (deprecated)** {#webrtc-modifier}
+
+> **Deprecation notice**
+>
+> This modifier is deprecated and is no longer supported. Rules with it are considered as invalid.
+> If you need to suppress WebRTC, consider using the `nowebrtc` [scriptlet](#scriptlets).
+
+The rule applies only to WebRTC connections.
+
+**Examples**
+
+* `||example.com^$webrtc,domain=example.org` blocks webRTC connections to `example.com` for `example.org`.
+* `@@*$webrtc,domain=example.org` disables the RTC wrapper for `example.org`.
 
 #### Exception modifiers {#exception-modifiers}
 

--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -225,7 +225,7 @@ The following modifiers are the most simple and frequently used. Basically, they
 
 #### **`$app`** {#app-modifier}
 
-This modifier lets you narrow the rule coverage down to a specific application (or a list of applications). This might be not too important on Windows and Mac, but this is very important on mobile where some of the filtering rules must be application-specific.
+This modifier lets you narrow the rule coverage down to a specific application (or a list of applications). This might be not too important on Windows and Mac, but this is very important on mobile devices where some of the filtering rules must be app-specific.
 
 * Android — use the app package name, e.g. `org.example.app`.
 * Windows — use the process name, e.g. `chrome.exe`.

--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -367,10 +367,10 @@ The modifier `":" h_value` part may be omitted. In that case the modifier matche
 
 **Examples**
 
-* `||example.com^$header=set-cookie:foo` blocks requests which responses have the `Set-Cookie` header with the value matching `foo` literally.
-* `||example.com^$header=set-cookie` blocks requests which responses have the `Set-Cookie` header with any value.
-* `@@||example.com^$header=set-cookie:/foo\, bar\$/` unblocks requests which responses have the `Set-Cookie` header with value matching the `foo, bar$` regular expression.
-* `@@||example.com^$header=set-cookie` unblocks requests which responses have a `Set-Cookie` header with any value.
+* `||example.com^$header=set-cookie:foo` blocks requests whose responses have the `Set-Cookie` header with the value matching `foo` literally.
+* `||example.com^$header=set-cookie` blocks requests whose responses have the `Set-Cookie` header with any value.
+* `@@||example.com^$header=set-cookie:/foo\, bar\$/` unblocks requests whose responses have the `Set-Cookie` header with value matching the `foo, bar$` regular expression.
+* `@@||example.com^$header=set-cookie` unblocks requests whose responses have a `Set-Cookie` header with any value.
 
 #### **`$important`** {#important-modifier}
 
@@ -783,7 +783,7 @@ Disables all generic [cosmetic rules](#cosmetic-rules) on pages that correspond 
 
 **Examples**
 
-* `@@||example.com^generichide` disables generic cosmetic rules on any pages at `example.com` and its subdomains.
+* `@@||example.com^$generichide` disables generic cosmetic rules on any pages at `example.com` and its subdomains.
 
 ### Advanced capabilities
 
@@ -852,7 +852,7 @@ In that case, the `$badfilter` rule will disable the corresponding rule for doma
 
 #### **`$cookie`** {#cookie-modifier}
 
-The `$cookie` modifier completely changes rule behavior. Instead of blocking a request, this modifier makes us suppress or modify the `Cookie` and `Set-Cookie` headers.
+The `$cookie` modifier completely changes rule behavior. Instead of blocking a request, this modifier makes AdGuard suppress or modify the `Cookie` and `Set-Cookie` headers.
 
 > **Multiple rules matching a single request**
 >
@@ -903,7 +903,7 @@ every time AdGuard encounters a cookie called `NAME` in a request to `example.or
 
 #### **`$csp`** {#csp-modifier}
 
-This modifier completely changes the rule behavior. If it is applied to a rule, it will not block the matching request. The response headers are going to be modified instead.
+This modifier completely changes the rule behavior. If it is applied to a rule, the rule will not block the matching request. Response headers will be modified instead.
 
 > In order to use this type of rules, it is required to have the basic understanding of the [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) security layer.
 
@@ -964,10 +964,10 @@ Basic URL exceptions shall not disable rules with `$hls` modifier. They can be d
 
 > **Restrictions**
 >
-> * `$hls` rules are only allowed in trusted filters.
-> * `$hls` rules are not compatible with any other modifiers except `$domain`, `$third-party`, `$app`, `$important`, `$match-case`, and `$xmlhttprequest`.
-> * `$hls` rules only apply to HLS playlists, which are UTF-8 encoded text starting with the line `#EXTM3U`. Any other response will not be modified by these rules.
-> * `$hls` rules do not apply if the size of the original response is more than 3 MB.
+> * `$hls` rules are only allowed in trusted filters
+> * `$hls` rules are not compatible with any other modifiers except `$domain`, `$third-party`, `$app`, `$important`, `$match-case`, and `$xmlhttprequest`
+> * `$hls` rules only apply to HLS playlists, which are UTF-8 encoded text starting with the line `#EXTM3U`. Any other response will not be modified by these rules
+> * `$hls` rules do not apply if the size of the original response is more than 3 MB
 
 > **Note**
 >
@@ -1317,7 +1317,7 @@ This is basically a Firewall-like rule allowing to fully block or unblock access
 
 #### **`$permissions`** {#permissions-modifier}
 
-This modifier completely changes the rule behavior. If it is applied to a rule, it will not block the matching request. The response headers are going to be modified instead.
+This modifier completely changes the rule behavior. If it is applied to a rule, the rule will not block the matching request. Response headers will be modified instead.
 
 > In order to use this type of rules, it is required to have a basic understanding of the [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy) security layer.
 

--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -235,7 +235,7 @@ This modifier lets you narrow the rule coverage down to a specific application (
 
 **Examples**
 
-* `||baddomain.com^$app=org.example.app` — a rule to block requests that match the specified mask, and are sent from the `org.example.app` Android app.
+* `||baddomain.com^$app=org.example.app` — a rule to block requests that match the specified mask and are sent from the `org.example.app` Android app.
 * `||baddomain.com^$app=org.example.app1|org.example.app2` — the same rule, but it works for both `org.example.app1` and `org.example.app2` apps.
 
 If you want the rule not to be applied to certain apps, start the app name with `~` sign.

--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -236,11 +236,11 @@ This modifier lets you narrow the rule coverage down to a specific application (
 **Examples**
 
 * `||baddomain.com^$app=org.example.app` — a rule to block requests that match the specified mask and are sent from the `org.example.app` Android app.
-* `||baddomain.com^$app=org.example.app1|org.example.app2` — the same rule, but it works for both `org.example.app1` and `org.example.app2` apps.
+* `||baddomain.com^$app=org.example.app1|org.example.app2` — the same rule but it works for both `org.example.app1` and `org.example.app2` apps.
 
-If you want the rule not to be applied to certain apps, start the app name with `~` sign.
+If you want the rule not to be applied to certain apps, start the app name with the `~` sign.
 
-* `||baddomain.com^$app=~org.example.app` — a rule to block requests that match the specified mask, and are sent from any app save for the `org.example.app`.
+* `||baddomain.com^$app=~org.example.app` — a rule to block requests that match the specified mask and are sent from any app save for the `org.example.app`.
 * `||baddomain.com^$app=~org.example.app1|~org.example.app2` — same as above, but now two apps are excluded: `org.example.app1` and `org.example.app2`.
 
 > **Compatibility with different versions of AdGuard**
@@ -385,7 +385,7 @@ The `$important` modifier applied to a rule increases its priority over any othe
 ```
 
 ```
-! if the exception rule also has `$important` modifier it will prevail, so no requests will not be blocked
+! if the exception rule also has `$important` modifier, it will prevail and requests won't be blocked
 ||example.org^$important
 @@||example.org^$important
 ```
@@ -444,7 +444,7 @@ AdGuard will try to close the browser tab with any address that matches a blocki
 
 #### **`$third-party`** {#third-party-modifier}
 
-A restriction of third-party and own requests. A third-party request is a request from a different domain. For example, a request to `example.org`, from `domain.com` is a third-party request.
+A restriction of third-party and own requests. A third-party request is a request from a different domain. For example, a request to `example.org` from `domain.com` is a third-party request.
 
 > **Note**
 >
@@ -457,9 +457,9 @@ If there is a `$third-party` modifier, the rule is only applied to third-party r
 
 **`$third-party`:**
 
-* `||domain.com^$third-party` — this rule applies to all domains, except `domain.com` and its subdomains. A third-party request example: `http://example.org/banner.jpg`.
+* `||domain.com^$third-party` — this rule applies to all domains, except `domain.com` and its subdomains. An example of a third-party request: `http://example.org/banner.jpg`.
 
-If there is a `$~third-party` modifier, the rule is only applied to the requests that are not from third-party. Which means, they have to be sent from the same domain.
+If there is a `$~third-party` modifier, the rule is only applied to the requests that are not from third parties. Which means, they have to be sent from the same domain.
 
 **`$~third-party`:**
 
@@ -563,7 +563,7 @@ The rule corresponds to requests caused by either `navigator.sendBeacon()` or th
 
 > **Compatibility with different versions of AdGuard**
 >
-> AdGuard for Windows, Mac, Android often cannot accurately detect `navigator.sendBeacon()`. For reliable detection, use AdGuard Browser extension.
+> AdGuard for Windows, Mac, and Android often cannot accurately detect `navigator.sendBeacon()`. For reliable detection, use AdGuard Browser Extension.
 
 #### **`$script`** {#script-modifier}
 
@@ -596,7 +596,7 @@ The rule applies only to ajax requests (requests sent via javascript object `XML
 
 > **Compatibility with different versions of AdGuard**
 >
-> AdGuard for Windows, Mac, Android often cannot accurately detect this type and sometimes detects it as [`$other`](#other-modifier) or [`$script`](#script-modifier). For reliable detection, use AdGuard Browser extension.
+> AdGuard for Windows, Mac, Android often cannot accurately detect this type and sometimes detects it as [`$other`](#other-modifier) or [`$script`](#script-modifier). For reliable detection, use AdGuard Browser Extension.
 
 #### **`$object-subrequest` (deprecated)** {#object-subrequest-modifier}
 
@@ -736,7 +736,7 @@ The list of the available modifier options:
 
 > **Compatibility with different versions of AdGuard**
 >
-> * Stealth Mode is available in AdGuard for Windows, Mac, Android, and AdGuard Browser extension. All other products will ignore the rules with `$stealth` modifier.
+> * Stealth Mode is available in AdGuard for Windows, Mac, Android, and AdGuard Browser Extension. All other products will ignore the rules with `$stealth` modifier.
 > * `$stealth` modifier with specific options is supported by AdGuard for Windows, Mac, and Android, **running CoreLibs version 1.10 or later**.
 
 #### **`$urlblock`** {#urlblock-modifier}
@@ -775,15 +775,15 @@ Disables generic basic rules on pages that correspond to exception rule.
 
 **Examples**
 
-* `@@||example.com^$genericblock` — disables generic basic rules on any pages at `example.com` and all subdomains.
+* `@@||example.com^$genericblock` disables generic basic rules on any pages at `example.com` and all subdomains.
 
 ##### **`$generichide`** {#generichide-modifier}
 
-Disables all generic [cosmetic rules](#cosmetic-rules) on pages that correspond to exception rule.
+Disables all generic [cosmetic rules](#cosmetic-rules) on pages that correspond to the exception rule.
 
 **Examples**
 
-* `@@||example.com^generichide` — disables generic cosmetic rules on any pages at `example.com` and all subdomains.
+* `@@||example.com^generichide` disables generic cosmetic rules on any pages at `example.com` and its subdomains.
 
 ### Advanced capabilities
 
@@ -812,7 +812,7 @@ These modifiers are able to completely change the behaviour of basic rules.
 
 #### **`$all`** {#all-modifier}
 
-`$all` modifier is made of [`$document`](#document-modifier), [`$popup`](#popup-modifier), [`$csp`](#csp-modifier) modifiers. E.g. rule `||example.org^$all` is converting into such set of rules:
+`$all` modifier is made of [`$document`](#document-modifier), [`$popup`](#popup-modifier), and [`$csp`](#csp-modifier) modifiers. E.g. rule `||example.org^$all` is converting into such a set of rules:
 ```
 ||example.org^$document,popup
 ||example.org^$csp=script-src 'self' 'unsafe-eval' http: https: data: blob: mediastream: filesystem:
@@ -1071,7 +1071,7 @@ preroll.ts
 [JSONPath](https://goessner.net/articles/JsonPath/) expression. They do not modify responses which are not
 valid JSON documents.
 
-> In AdGuard for Windows, Mac, and Android, **running CoreLibs version 1.11 or later**, `$jsonprune` also supports modifying JSONP (padded JSON) documents.
+> In AdGuard for Windows, Mac, and Android **running CoreLibs v1.11 or later**, `$jsonprune` also supports modifying JSONP (padded JSON) documents.
 
 **Syntax**
 
@@ -1216,7 +1216,7 @@ Basic URL exceptions shall not disable rules with `$jsonprune` modifier. They ca
 
 **Nested JSONPath expressions**
 
-> In AdGuard for Windows, Mac and Android, **running CoreLibs version 1.11 or later**, JSONPath expressions may be used as keys in filter expressions.
+> In AdGuard for Windows, Mac and Android **running CoreLibs v1.11 or later**, JSONPath expressions may be used as keys in filter expressions.
 
 * `||example.org^$jsonprune=\$.elems[?(has "\$.a.b.c")]` removes all children of `elems` which have a property selectable by the JSONPath expression `$.a.b.c`.
 
@@ -1293,7 +1293,7 @@ Basic URL exceptions shall not disable rules with `$jsonprune` modifier. They ca
 
 #### **`$network`** {#network-modifier}
 
-This is basically a Firewall-kind of rules allowing to fully block or unblock access to a specified remote address.
+This is basically a Firewall-like rule allowing to fully block or unblock access to a specified remote address.
 
 1. `$network` rules match **IP addresses only**! You cannot use them to block or unblock access to a domain.
 2. To match an IPv6 address, you have to use the collapsed syntax, e.g. use `[2001:4860:4860::8888]$network` instead of `[2001:4860:4860:0:0:0:0:8888]$network`.
@@ -1319,9 +1319,9 @@ This is basically a Firewall-kind of rules allowing to fully block or unblock ac
 
 This modifier completely changes the rule behavior. If it is applied to a rule, it will not block the matching request. The response headers are going to be modified instead.
 
-> In order to use this type of rules, it is required to have the basic understanding of the [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy) security layer.
+> In order to use this type of rules, it is required to have a basic understanding of the [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy) security layer.
 
-For the requests matching a `$permissions` rule, AdGuard strengthens response's permissions policy by adding additional permission policy equal to the `$permissions` modifier contents. `$permissions` rules are applied independently from any other rule type. Other basic rules have no influence on it **save for document-level exceptions** (see the examples section).
+For the requests matching a `$permissions` rule, AdGuard strengthens response's permissions policy by adding an additional permission policy equal to the `$permissions` modifier contents. `$permissions` rules are applied independently from any other rule type. Other basic rules have no influence on it **save for document-level exceptions** (see the examples section).
 
 > **Multiple rules matching a single request.**
 >
@@ -1497,7 +1497,7 @@ Use `@@` to negate `$removeheader`:
 
 > **Compatibility with different versions of AdGuard**
 >
-> Rules with `$removeheader` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard Browser extension for Chrome, Firefox, Edge.
+> Rules with `$removeheader` modifier are supported by AdGuard for Windows, Mac, and Android, and AdGuard Browser extension for Chrome, Firefox, and Edge.
 
 #### **`$removeparam`** {#removeparam-modifier}
 
@@ -1511,7 +1511,7 @@ Rules with `$removeparam` modifier are intended to strip query parameters from r
 
 **Basic syntax**
 
-* `$removeparam=param` — removes query parameter with the name `param` from URLs of any request, e.g. a request to `http://example.com/page?param=1&another=2` will be transformed to `http://example.com/page?another=2`.
+* `$removeparam=param` removes query parameter with the name `param` from URLs of any request, e.g. a request to `http://example.com/page?param=1&another=2` will be transformed into `http://example.com/page?another=2`.
 
 > `$removeparam` basic syntax is supported starting with v1.7 of [CoreLibs](https://adguard.com/en/blog/introducing-corelibs.html) and v3.6 of AdGuard Browser Extension.
 
@@ -1521,7 +1521,7 @@ You can also use regular expressions to match query parameters and/or their valu
 
 * `$removeparam=/regexp/[options]` — removes query parameters that matches the `regexp` regular expression from URLs of any request. Unlike basic syntax, it means *"remove query parameters normalized to a `name=value` string which match the `regexp` regular expression"*. `[options]` here is the list of regular expression options. At the moment, the only supported option is `i` which makes matching case-insensitive.
 
-> `$removeparam` syntax for regular expressions will be supported starting with v1.8 of CoreLibs and v4.0 of AdGuard Browser Extension. For now, use the simplified version: `$removeparam=param`.
+> `$removeparam` syntax for regular expressions will be supported starting with CoreLibs v1.8 and AdGuard Browser Extension v4.0. For now, use the simplified version: `$removeparam=param`.
 
 > **Escaping special characters**
 >
@@ -1529,7 +1529,7 @@ You can also use regular expressions to match query parameters and/or their valu
 
 > **Note**
 >
-> Regexp-type rules target both name and value of the parameter. In order to minimize the chance of mistakes, it is safer to start every regexp with `/^` unless you specifically target parameter values.
+> Regexp-type rules target both name and value of the parameter. To minimize mistakes, it is safer to start every regexp with `/^` unless you specifically target parameter values.
 
 > We will try to detect and ignore unescaped `$` automatically using a simple rule of thumb:
 > It is not an options delimiter if all three are true:
@@ -1574,7 +1574,7 @@ $removeparam=/^(utm_content|utm_campaign|utm_referrer)=/
 
 With these rules some [UTM parameters](https://en.wikipedia.org/wiki/UTM_parameters) will be stripped out from any request, except that requests to `example.com` will not be stripped at all, e.g. `http://google.com/page?utm_source=s&utm_referrer=fb.com&utm_content=img` will be transformed to `http://google.com/page`, but `http://example.com/page?utm_source=s&utm_referrer=fb.com&utm_content=img` will not be affected by the blocking rule.
 
-* `$removeparam=utm_source` — removes `utm_source` query parameter from all requests.
+* `$removeparam=utm_source` removes `utm_source` query parameter from all requests.
 
 * `$removeparam=/utm_.*/` — removes all `utm_* query` parameters from URL queries of any request, e.g. a request to `http://example.com/page?utm_source=test` will be transformed to `http://example.com/page`.
 
@@ -1610,7 +1610,7 @@ With these rules, specified UTM parameters will be removed from any request save
 
 > ##### **Compatibility with different versions of AdGuard** {#removeparam-modifier-compatibility}
 >
-> * Rules with `$removeparam` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard browser extensions for Chrome, Firefox, Edge.
+> * Rules with `$removeparam` modifier are supported by AdGuard for Windows, Mac, and Android and AdGuard Browser Extension for Chrome, Firefox, and Edge.
 >
 > * `POST` request types are supported only by AdGuard for Windows, Mac, and Android, **running CoreLibs version 1.10 or later**.
 
@@ -1682,7 +1682,7 @@ http://regexr.com/3cesk
 
 > **Compatibility with different versions of AdGuard**
 >
-> Rules with `$replace` modifier are supported by AdGuard for Windows, Mac, Android, and AdGuard Browser extension for Firefox. Such rules do not work in extensions for other browsers because they are unable to modify content on the network level.
+> Rules with `$replace` modifier are supported by AdGuard for Windows, Mac, and Android and AdGuard Browser Extension for Firefox. Such rules do not work in extensions for other browsers because they are unable to modify content on the network level.
 
 > **Restrictions**
 >


### PR DESCRIPTION
I propose 2 things:
1) Keep all modifiers alphabetically sorted. As the number of them increases, it becomes harder to find the specific modifier in the unsorted list.
2) Make `basic modifiers` section contain only the modifiers that limits the scope of rule application, and `advanced modifiers` - the ones that actually change the behavior of the rules.