### PR TITLE
Remove all wide rules limitations except rule length

### DIFF
--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -156,6 +156,12 @@ Browser detects a blocked request as completed with an error.
 
 :::
 
+:::note Rule length
+
+Rules shorter than 4 characters are considered incorrect and will be ignored.
+
+:::
+
 ### Basic rule syntax {#basic-rules-syntax}
 
 ```text
@@ -203,68 +209,6 @@ For example, `/banner\d+/$third-party` this rule will apply the regular expressi
 AdGuard Safari and AdGuard for iOS do not fully support regular expressions because of [Content Blocking API restrictions](https://webkit.org/blog/3476/content-blockers-first-look/) (look for "The Regular expression format" section).
 
 :::
-
-### Restrictions on rules application {#rules-restrictions}
-
-Rules that match an arbitrarily large number of URLs are considered incorrect and will be ignored. This can happen if the rule doesn't contain a mask, or if the mask matches any URL with a certain protocol.
-
-This rule will be ignored:
-
-```text
-|http://$replace=/a/b/
-```
-
-This limitation can be circumvented by using a `/.*/` regular expression inside the mask.
-
-This rule will not be ignored:
-
-```text
-/.*/$replace=/a/b/
-```
-
-**Exceptions**
-
-This rule validation is not applied in the following cases:
-
-1. The rule contains [`$domain`](#domain-modifier) modifier that points to a specific domain list
-
-    These rules will not be ignored:
-
-    ```text
-    $domain=example.com,script
-    $domain=example.*,script
-    ```
-
-    This rule will be ignored because of domain negation, which causes too wide of a rule application scope:
-
-    ```text
-    $domain=~example.com,script
-    ```
-
-1. The rule contains [`$app`](#app-modifier) modifier that points to a specific app list
-
-    This rule will not be ignored:
-
-    ```text
-    $app=curl,document
-    ```
-
-    This rule will be ignored because of app negation, which causes too wide of a rule application scope:
-
-    ```text
-    $app=~curl,document
-    ```
-
-1. The rule contains one or more modifiers from among [`$cookie`](#cookie-modifier), [`$removeparam`](#removeparam-modifier), [`$removeheader`](#removeheader-modifier), [`$stealth`](#stealth-modifier)
-
-    These rules will not be ignored:
-
-    ```text
-    $removeparam=cx_recsWidget
-    $cookie=ibbid
-    $removeheader=location
-    $stealth
-    ```
 
 ### Wildcard support for TLD (top-level domains) {#wildcard-for-tld}
 


### PR DESCRIPTION
As part of https://github.com/AdguardTeam/CoreLibs/issues/1809

Removed all wide rules conditions. Only one left is rule length - min 4 characters.