### PR TITLE
activation.md - remove step in Android instruction

### DIFF
--- a/docs/general/license/activation.md
+++ b/docs/general/license/activation.md
@@ -65,10 +65,6 @@ Alternatively, you can use a [license key](../what-is#license-key) to activate t
 
     ![Activating a license *mobile_border](https://cdn.adtidy.org/blog/new/sbxttactivate-license.png)
 
-    Alternatively, you can tap *I have a license* on the following screen and activate your license with one of the above-mentioned methods.
-
-    ![I have a license *mobile](https://cdn.adtidy.org/blog/new/fq28vi-have-a-license.png)
-
 ### Activating AdGuard for iOS
 
 1. Tap *Settings*, then select *License*.


### PR DESCRIPTION
Removed a step for Android due to the fact that there's no "I have a license" option in the new Promotional screen