### PR TITLE
Update escaped chars list for domain modifier

### DIFF
--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -384,7 +384,7 @@ entry_i = ( regular_domain / any_tld_domain / regexp )
 
 - **`regular_domain`** — a regular domain name (`domain.com`). Corresponds the specified domain and its subdomains. It is matched lexicographically.
 - **`any_tld_domain`** — a domain name ending with a wildcard character as a [public suffix](https://publicsuffix.org/learn/), e.g. for `example.*` it is `co.uk` in `example.co.uk`. Corresponds to the specified domain and its subdomains with any public suffix. It is matched lexicographically.
-- **`regexp`** — a regular expression, starts and ends with `/`. The pattern works the same way as in the basic URL rules, but the characters `/`, `$`, `,` and `|` must be escaped with `\`.
+- **`regexp`** — a regular expression, starts and ends with `/`. The pattern works the same way as in the basic URL rules, but the characters `/`, `$`, `,`, and `|` must be escaped with `\`.
 
 :::info
 

--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -384,7 +384,7 @@ entry_i = ( regular_domain / any_tld_domain / regexp )
 
 - **`regular_domain`** — a regular domain name (`domain.com`). Corresponds the specified domain and its subdomains. It is matched lexicographically.
 - **`any_tld_domain`** — a domain name ending with a wildcard character as a [public suffix](https://publicsuffix.org/learn/), e.g. for `example.*` it is `co.uk` in `example.co.uk`. Corresponds to the specified domain and its subdomains with any public suffix. It is matched lexicographically.
-- **`regexp`** — a regular expression, starts and ends with `/`. The pattern works the same way as in the basic URL rules, but the characters `/`, `$`, and `|` must be escaped with `\`.
+- **`regexp`** — a regular expression, starts and ends with `/`. The pattern works the same way as in the basic URL rules, but the characters `/`, `$`, `,` and `|` must be escaped with `\`.
 
 :::info
 


### PR DESCRIPTION
`,` should be escaped within regexps, otherwise modifier list parser considers it as a separator, e.g. `[$domain=/^webteizle\d{0\,2}\.info/]##body`

Reference: https://github.com/AdguardTeam/tsurlfilter/issues/136