### PR TITLE
[GH-issue-594] Add new section to how-ad-blocking-works.md

### DIFF
--- a/docs/general/ad-filtering/how-ad-blocking-works.md
+++ b/docs/general/ad-filtering/how-ad-blocking-works.md
@@ -31,7 +31,7 @@ And even when a rule finally gets added to a filter, it doesn't mean that it sta
 
 AdGuard users [have access to a special web reporting tool](https://reports.adguard.com/new_issue.html). Thanks to user complaints, filter developers can focus on correcting their filter lists and not on scouring the Internet for new and old unblocked ads.
 
-Filters can do more than just block ads. There are filters that block tracking, social media widgets, and annoyances such as cookie notices. Different users may choose different combinations of filters to match their personal preferences. There are websites like [filterlists.com](https://filterlists.com/) that are dedicated to filter lists and have huge databases.
+Filters can do more than just block ads. There are filters that block tracking, social media widgets, and annoyances, such as cookie notices. Different users may choose different combinations of filters to match their personal preferences. There are websites like [filterlists.com](https://filterlists.com/) that are dedicated to filter lists and have huge databases.
 
 We develop and maintain [our own set of filter lists](../adguard-filters) that can be used with AdGuard or other ad blockers.
 
@@ -79,7 +79,7 @@ AdGuard Tracking Protection filter blocks tracking requests, such as `youtube.co
 
 ### Examples of allowed requests
 
-AdGuard Base filter allows non-ad requests such as `www.google.com/complete/search?q=`.
+AdGuard Base filter allows non-ad requests, such as `www.google.com/complete/search?q=`.
 
 Filter unblocking search ads and self-promotion allows requests to search ad-related domains, such as `www.google.com/aclk?`.
 

--- a/docs/general/ad-filtering/how-ad-blocking-works.md
+++ b/docs/general/ad-filtering/how-ad-blocking-works.md
@@ -67,17 +67,17 @@ There are other types of filtering rules, but they require more advanced technic
 
 AdGuard handles requests according to filters, user rules and settings enabled by the user. As a result, a request can be blocked, modified, allowed or, when nothing is done to it, just processed.
 
-A detailed information about how each request was handled by your AdGuard can be found in the *Filtering log* (AdGuard for Windows, AdGuard for Mac, AdGuard Browser extension) or *Recent activity* (AdGuard for iOS, AdGuard for Android).
+Detailed information on how each request of yours has been handled by AdGuard can be found in the *Filtering log* (AdGuard for Windows, AdGuard for Mac, AdGuard Browser Extension) or *Recent activity* (AdGuard for iOS, AdGuard for Android).
 
 Regarding AdGuard filters, you can also check [our filter policy](../filter-policy), which describes in detail what and why each of our filters blocks.
 
-### Blocked requests examples
+### Examples of blocked requests
 
 AdGuard DNS filter blocks requests to ad domains, such as `ad.doubleclick.net`.
 
 AdGuard Tracking Protection filter blocks tracking requests, such as `youtube.com/youtubei/log_event?`.
 
-### Allowed requests examples
+### Examples of allowed requests
 
 AdGuard Base filter allows non-ad requests such as `www.google.com/complete/search?q=`.
 
@@ -85,7 +85,7 @@ Filter unblocking search ads and self-promotion allows search ads requests, such
 
 Requests to websites that are added by the user to *Allowlist* are allowed.
 
-### Modified requests examples
+### Examples of modified requests
 
 Tracking protection feature with protection level set to *High* enables AdGuard URL Tracking filter which modifies requests by removing tracking parameters from them:
 
@@ -96,7 +96,7 @@ Tracking protection feature with protection level set to *High* enables AdGuard 
 `https://www.gog.com/game/spec_ops_the_line?pp=2863d7ae605104eeef364e3f164d3404e20f680c&gad_source=1` →
 `https://www.gog.com/game/spec_ops_the_line`
 
-Please note that *Modified* events you see in the Filtering log or Recent activity do not refer only to the cases when a request is modified, but also when:
+Please note that *modified* events you see in the Filtering log or Recent activity refer not only to the cases when a request is modified, but also when:
 
 - something on the page is changed (usually by cosmetic rules)
 - the response is modified

--- a/docs/general/ad-filtering/how-ad-blocking-works.md
+++ b/docs/general/ad-filtering/how-ad-blocking-works.md
@@ -97,7 +97,6 @@ Tracking protection feature with protection level set to *High* enables AdGuard 
 `https://www.gog.com/game/spec_ops_the_line`
 
 > Please note that *Modified* events you see in the Filtering log or Recent activity do not refer only to the cases when a request is modified, but also when:
-> 
+>
 > - something on the page is changed (usually by cosmetic rules)
 > - the response is modified
->

--- a/docs/general/ad-filtering/how-ad-blocking-works.md
+++ b/docs/general/ad-filtering/how-ad-blocking-works.md
@@ -62,3 +62,40 @@ These rules are quite complicated and require the ad blocker to be granted certa
 There are other types of filtering rules, but they require more advanced technical knowledge to understand how they work. If you are interested, [check out our comprehensive guide on filtering rules in the linked article](../create-own-filters).
 
 :::
+
+## Types of request handling in AdGuard
+
+AdGuard handles requests according to filters, user rules and settings enabled by the user. As a result, a request can be blocked, modified, allowed or, when nothing is done to it, just processed.
+
+A detailed information about how each request was handled by your AdGuard can be found in the *Filtering log* (AdGuard for Windows, AdGuard for Mac, AdGuard Browser extension) or *Recent activity* (AdGuard for iOS, AdGuard for Android).
+
+Regarding AdGuard filters, you can also check [our filter policy](filter-policy.md), which describes in detail what and why each of our filters blocks.
+
+### Blocked requests examples
+
+AdGuard DNS filter blocks requests to ad domains, such as `ad.doubleclick.net`.
+
+AdGuard Tracking Protection filter blocks tracking requests, such as `youtube.com/youtubei/log_event?`.
+
+### Allowed requests examples
+
+AdGuard Base filter allows non-ad requests such as `www.google.com/complete/search?q=`.
+
+Filter unblocking search ads and self-promotion allows search ads requests, such as `www.google.com/aclk?`.
+
+Requests to websites that are added by the user to *Allowlist* are allowed.
+
+### Modified requests examples
+
+Tracking protection feature with protection level set to *High* enables AdGuard URL Tracking filter which modifies requests by removing tracking parameters from them:
+
+`https://www.rentio.jp/products/ax-n1b?click_from=top_newitems` → `https://www.rentio.jp/products/ax-n1b`
+
+`https://www.baseballchannel.jp/npb/183688/?ref=ise` → `https://www.baseballchannel.jp/npb/183688/`
+
+`https://www.gog.com/game/spec_ops_the_line?pp=2863d7ae605104eeef364e3f164d3404e20f680c&gad_source=1` → 
+`https://www.gog.com/game/spec_ops_the_line`
+
+> Please note that *Modified* events you see in the Filtering log or Recent activity do not refer only to the cases when a request is modified, but also when: 
+> - something on the page is changed (usually by cosmetic rules)
+> - the response is modified

--- a/docs/general/ad-filtering/how-ad-blocking-works.md
+++ b/docs/general/ad-filtering/how-ad-blocking-works.md
@@ -96,7 +96,8 @@ Tracking protection feature with protection level set to *High* enables AdGuard 
 `https://www.gog.com/game/spec_ops_the_line?pp=2863d7ae605104eeef364e3f164d3404e20f680c&gad_source=1` → 
 `https://www.gog.com/game/spec_ops_the_line`
 
-> Please note that *Modified* events you see in the Filtering log or Recent activity do not refer only to the cases when a request is modified, but also when: 
+> Please note that *Modified* events you see in the Filtering log or Recent activity do not refer only to the cases when a request is modified, but also when:
+> 
 > - something on the page is changed (usually by cosmetic rules)
 > - the response is modified
 >

--- a/docs/general/ad-filtering/how-ad-blocking-works.md
+++ b/docs/general/ad-filtering/how-ad-blocking-works.md
@@ -81,7 +81,7 @@ AdGuard Tracking Protection filter blocks tracking requests, such as `youtube.co
 
 AdGuard Base filter allows non-ad requests such as `www.google.com/complete/search?q=`.
 
-Filter unblocking search ads and self-promotion allows search ads requests, such as `www.google.com/aclk?`.
+Filter unblocking search ads and self-promotion allows requests to search ad-related domains, such as `www.google.com/aclk?`.
 
 Requests to websites that are added by the user to *Allowlist* are allowed.
 

--- a/docs/general/ad-filtering/how-ad-blocking-works.md
+++ b/docs/general/ad-filtering/how-ad-blocking-works.md
@@ -96,7 +96,7 @@ Tracking protection feature with protection level set to *High* enables AdGuard 
 `https://www.gog.com/game/spec_ops_the_line?pp=2863d7ae605104eeef364e3f164d3404e20f680c&gad_source=1` → 
 `https://www.gog.com/game/spec_ops_the_line`
 
-> Please note that *Modified* events you see in the Filtering log or Recent activity do not refer only to the cases when a request is modified, but also when:
->
-> - something on the page is changed (usually by cosmetic rules)
-> - the response is modified
+Please note that *Modified* events you see in the Filtering log or Recent activity do not refer only to the cases when a request is modified, but also when:
+
+ - something on the page is changed (usually by cosmetic rules)
+ - the response is modified

--- a/docs/general/ad-filtering/how-ad-blocking-works.md
+++ b/docs/general/ad-filtering/how-ad-blocking-works.md
@@ -69,7 +69,7 @@ AdGuard handles requests according to filters, user rules and settings enabled b
 
 A detailed information about how each request was handled by your AdGuard can be found in the *Filtering log* (AdGuard for Windows, AdGuard for Mac, AdGuard Browser extension) or *Recent activity* (AdGuard for iOS, AdGuard for Android).
 
-Regarding AdGuard filters, you can also check [our filter policy](filter-policy.md), which describes in detail what and why each of our filters blocks.
+Regarding AdGuard filters, you can also check [our filter policy](../filter-policy), which describes in detail what and why each of our filters blocks.
 
 ### Blocked requests examples
 
@@ -99,3 +99,4 @@ Tracking protection feature with protection level set to *High* enables AdGuard 
 > Please note that *Modified* events you see in the Filtering log or Recent activity do not refer only to the cases when a request is modified, but also when: 
 > - something on the page is changed (usually by cosmetic rules)
 > - the response is modified
+>

--- a/docs/general/ad-filtering/how-ad-blocking-works.md
+++ b/docs/general/ad-filtering/how-ad-blocking-works.md
@@ -93,10 +93,10 @@ Tracking protection feature with protection level set to *High* enables AdGuard 
 
 `https://www.baseballchannel.jp/npb/183688/?ref=ise` → `https://www.baseballchannel.jp/npb/183688/`
 
-`https://www.gog.com/game/spec_ops_the_line?pp=2863d7ae605104eeef364e3f164d3404e20f680c&gad_source=1` → 
+`https://www.gog.com/game/spec_ops_the_line?pp=2863d7ae605104eeef364e3f164d3404e20f680c&gad_source=1` →
 `https://www.gog.com/game/spec_ops_the_line`
 
 Please note that *Modified* events you see in the Filtering log or Recent activity do not refer only to the cases when a request is modified, but also when:
 
- - something on the page is changed (usually by cosmetic rules)
- - the response is modified
+- something on the page is changed (usually by cosmetic rules)
+- the response is modified


### PR DESCRIPTION
Added a new section "Types of request handling in AdGuard" to how-ad-blocking-works.md, that explains those types (blocked, allowed, modified) with some examples. Source of this change is proposal from a user: https://github.com/AdguardTeam/KnowledgeBase/issues/594 