### PR TITLE
[AGM-2450] Update AG for Mac's icloud-private-relay.md

### DIFF
--- a/docs/adguard-for-mac/solving-problems/icloud-private-relay.md
+++ b/docs/adguard-for-mac/solving-problems/icloud-private-relay.md
@@ -26,16 +26,16 @@ On Big Sur, AdGuard developed "split-tunnel" rules to avoid creating the "defaul
 
 On Monterey, iCloud Private Relay got introduced. Privacy features of the Mail app also use Private Relay servers.
 
-As a consequence, AdGuard can't work together with iCloud Private Relay and the Mail app privacy features:
+As a consequence, AdGuard can’t work together with iCloud Private Relay and the Mail app privacy features:
 
 1. iCloud Private Relay is applied to connections at the library level — before they reach the socket level, where AdGuard operates.
 2. iCloud Private Relay is implemented with HTTP/3 CONNECT proxies.
 3. Since AdGuard does not filter CONNECT HTTP/3 requests yet, it attempts to downgrade HTTP/3 proxy connections to HTTP/1.1, which results in blocking iCloud Private Relay traffic.
-4. When you use iCloud Private Relay and switch AdGuard into the "split-tunnel" mode, you can't open websites in Safari.
-5. To work around this issue for Monterey, we apply the "default route" rule. When Private Relay sees that rule, it disables itself automatically.
+4. When you use iCloud Private Relay and switch AdGuard into the Split-Tunnel mode, you can’t open websites in Safari.
+5. To work around this issue for Monterey, we apply the “default route” rule. When Private Relay sees that rule, it disables itself automatically.
 So, AdGuard works seamlessly on Monterey, but iCloud Private Relay gets disabled.
 
-The `network.extension.monterey.force.split.tunnel` option restores the "Big Sur" behavior, but this option may break access to websites due to (3) and (4).
+The `network.extension.monterey.force.split.tunnel` option restores the “Big Sur” behavior, but this option may break access to websites due to (3) and (4).
 We keep searching for a solution to this issue. One of the options is implementing HTTP/3 proxy filtering.
 
 ## Recommended solution

--- a/docs/adguard-for-mac/solving-problems/icloud-private-relay.md
+++ b/docs/adguard-for-mac/solving-problems/icloud-private-relay.md
@@ -30,7 +30,7 @@ As a consequence, AdGuard can't work together with iCloud Private Relay and the 
 
 1. iCloud Private Relay is applied to connections at the library level — before they reach the socket level, where AdGuard operates.
 2. iCloud Private Relay is implemented with HTTP/3 CONNECT proxies.
-3. Since AdGuard does not filter CONNECT HTTP/3 requests yet, it blocks HTTP/3 proxy connections, which results in blocking iCloud Private Relay traffic.
+3. Since AdGuard does not filter CONNECT HTTP/3 requests yet, it attempts to downgrade HTTP/3 proxy connections to HTTP/1.1, which results in blocking iCloud Private Relay traffic.
 4. When you use iCloud Private Relay and switch AdGuard into the "split-tunnel" mode, you can't open websites in Safari.
 5. To work around this issue for Monterey, we apply the "default route" rule. When Private Relay sees that rule, it disables itself automatically.
 So, AdGuard works seamlessly on Monterey, but iCloud Private Relay gets disabled.

--- a/docs/adguard-for-mac/solving-problems/icloud-private-relay.md
+++ b/docs/adguard-for-mac/solving-problems/icloud-private-relay.md
@@ -29,14 +29,14 @@ On Monterey, iCloud Private Relay got introduced. Privacy features of the Mail a
 As a consequence, AdGuard can't work together with iCloud Private Relay and the Mail app privacy features:
 
 1. iCloud Private Relay is applied to connections at the library level — before they reach the socket level, where AdGuard operates.
-2. iCloud Private Relay uses QUIC, which AdGuard can't filter in filtered apps because HTTP/3 filtering is not yet available.
-3. Consequently, AdGuard blocks QUIC, including iCloud Private Relay traffic — otherwise, ad blocking is impossible.
+2. iCloud Private Relay is implemented with HTTP/3 CONNECT proxies.
+3. Since AdGuard does not filter CONNECT HTTP/3 requests yet, it blocks HTTP/3 proxy connections, which results in blocking iCloud Private Relay traffic.
 4. When you use iCloud Private Relay and switch AdGuard into the "split-tunnel" mode, you can't open websites in Safari.
 5. To work around this issue for Monterey, we apply the "default route" rule. When Private Relay sees that rule, it disables itself automatically.
 So, AdGuard works seamlessly on Monterey, but iCloud Private Relay gets disabled.
 
-`network.extension.monterey.force.split.tunnel` restores the "Big Sur" behavior, but this option may break access to websites due to (3) and (4).
-We keep searching for a solution to this issue. One of the options is implementing HTTP/3 filtering.
+The `network.extension.monterey.force.split.tunnel` option restores the "Big Sur" behavior, but this option may break access to websites due to (3) and (4).
+We keep searching for a solution to this issue. One of the options is implementing HTTP/3 proxy filtering.
 
 ## Recommended solution
 


### PR DESCRIPTION
Correcting technical details behind iCloud Private Relay problem, which should make it clearer why HTTP/3 filtering feature (which was introduced in AdGuard for Mac v2.12) is not enough to fix the issue. All thanks to this user's feedback: https://github.com/AdguardTeam/KnowledgeBase/issues/693