### PR TITLE
Update installation.md - update macOS requirement to 12

### DIFF
--- a/docs/adguard-for-mac/installation.md
+++ b/docs/adguard-for-mac/installation.md
@@ -11,7 +11,7 @@ This article is about AdGuard for Mac, a multifunctional ad blocker that protect
 
 ## System requirements
 
-**Operating system version:** macOS 12 or higher
+**Operating system version:** macOS 12 or later
 
 **RAM:** at least 2 GB
 


### PR DESCRIPTION
Starting from [v2.18](https://adguard.com/en/versions/mac/release.html#version-21802089) AdGuard for Mac supports only macOS 12 or later