### PR TITLE
Move path-in-domain syntax under $path modifier

### DIFF
--- a/docs/general/ad-filtering/create-own-filters.md
+++ b/docs/general/ad-filtering/create-own-filters.md
@@ -4862,7 +4862,7 @@ Path-in-domain syntax works with all types of cosmetic rules (`##`, `#@#`, `#$#`
 
 :::info Compatibility
 
-Path-in-domain syntax has been introduced in [CoreLibs] v1.21.
+Path-in-domain syntax has been introduced in [CoreLibs] v1.20.
 
 :::
 


### PR DESCRIPTION
Path-in-domain is now a subsection of $path modifier instead of a separate cosmetic rules section, reflecting that it's an alternative syntax converted to $path internally.