### PR TITLE
Add Browser Assistant section to adguard-for-linux settings

### DIFF
--- a/docs/adguard-for-linux/settings.md
+++ b/docs/adguard-for-linux/settings.md
@@ -302,7 +302,7 @@ AdGuard Browser Assistant allows you to manage AdGuard protection directly from 
 
 AdGuard Browser Assistant is a browser extension. It allows you to quickly manage AdGuard for Linux:
 
-- Enable or disable protection for a specific website (a toggle under the website name)
+- Enable or disable protection for a specific website (the toggle under the website name)
 - Pause protection for 30 seconds
 - Disable protection (the pause icon in the upper right corner)
 - Manually block an ad

--- a/docs/adguard-for-linux/settings.md
+++ b/docs/adguard-for-linux/settings.md
@@ -291,3 +291,46 @@ adguard-cli import-settings -i "/path/to/settings.zip"
 ```
 
 The `-i` or `--input` flag is required and specifies the path to the settings archive to import.
+
+## AdGuard Browser Assistant
+
+AdGuard Browser Assistant allows you to manage AdGuard protection directly from your browser.
+
+![The Assistant window *mobile](https://cdn.adtidy.org/content/kb/ad_blocker/mac/assistant_window.png)
+
+### How it works
+
+AdGuard Browser Assistant is a browser extension. It allows you to quickly manage AdGuard for Linux:
+
+- Enable or disable protection for a specific website (a toggle under the website name)
+- Pause protection for 30 seconds
+- Disable protection (the pause icon in the upper right corner)
+- Manually block an ad
+- Report incorrect blocking
+- Manage HTTPS filtering (the lock icon next to the website name)
+
+### How to install
+
+To install Native Messaging manifests for browser integration, use:
+
+```sh
+adguard-cli install-browser-integration
+```
+
+To uninstall the manifests, use:
+
+```sh
+adguard-cli install-browser-integration --uninstall
+```
+
+**Install AdGuard Browser Assistant extension**:
+
+1. Open the [Assistant page](https://adguard.com/adguard-assistant/overview.html).
+1. Under your browser name, select *Install*.
+1. Install Assistant from your browser’s extension store.
+
+:::info Compatibility
+
+Support for AdGuard Browser Assistant is available starting from AdGuard for Linux v1.4.
+
+:::


### PR DESCRIPTION
Based on docs/adguard-for-mac/features/browser-assistant.md, adapted for AdGuard for Linux CLI.