### PR TITLE
Update DNS-over-QUIC link in iOS docs

### DIFF
--- a/docs/adguard-for-ios/features/dns-protection.md
+++ b/docs/adguard-for-ios/features/dns-protection.md
@@ -23,7 +23,7 @@ To be able to manage DNS settings, AdGuard apps require establishing a local VPN
 
 This section has two options: AdGuard and Native implementation. Basically, these are two methods of setting up DNS.
 
-In Native implementation, the DNS is handled by the system and not the app. This means that AdGuard doesn't have to create a local VPN. Sadly, this will not help you circumvent system restrictions and use AdGuard alongside other VPN-based applications — if any VPN is enabled, native DNS is ignored. Consequently, you won't be able to filter traffic locally or to use our brand new [DNS-over-QUIC protocol (DoQ)](https://adguard.com/en/blog/dns-over-quic.html).
+In Native implementation, the DNS is handled by the system and not the app. This means that AdGuard doesn't have to create a local VPN. Sadly, this will not help you circumvent system restrictions and use AdGuard alongside other VPN-based applications — if any VPN is enabled, native DNS is ignored. Consequently, you won't be able to filter traffic locally or to use our brand new [DNS-over-QUIC protocol (DoQ)](https://adguard-dns.io/blog/dns-over-quic.html).
 
 ### DNS servers {#dns-servers}
 


### PR DESCRIPTION
Fix the DNS-over-QUIC blog URL in docs/adguard-for-ios/features/dns-protection.md, replacing the old adguard.com link with the canonical adguard-dns.io URL